### PR TITLE
corrected string formatting postconditions

### DIFF
--- a/swagger_to/__init__.py
+++ b/swagger_to/__init__.py
@@ -77,7 +77,7 @@ def camel_case_split(identifier: str) -> List[str]:
 @icontract.require(lambda identifier: identifier != '', error=ValueError("Unexpected empty identifier"), enabled=True)
 @icontract.ensure(lambda result: '_' not in result)
 @icontract.ensure(lambda result: '-' not in result)
-@icontract.ensure(lambda result: result[0].isupper())
+@icontract.ensure(lambda result: result[0] == result[0].upper())
 @icontract.ensure(lambda result: result != '')
 def capital_camel_case(identifier: str) -> str:
     """
@@ -126,7 +126,7 @@ def capital_camel_case(identifier: str) -> str:
 @icontract.require(lambda identifier: identifier != '', error=ValueError("Unexpected empty identifier"), enabled=True)
 @icontract.ensure(lambda result: '_' not in result)
 @icontract.ensure(lambda result: '-' not in result)
-@icontract.ensure(lambda result: result[0].islower())
+@icontract.ensure(lambda result: result[0] == result[0].lower())
 @icontract.ensure(lambda result: result != '')
 def camel_case(identifier: str) -> str:
     """
@@ -178,7 +178,7 @@ def camel_case(identifier: str) -> str:
 
 @icontract.require(lambda identifier: identifier != '', error=ValueError("Unexpected empty identifier"), enabled=True)
 @icontract.ensure(lambda result: '-' not in result)
-@icontract.ensure(lambda result: result.islower())
+@icontract.ensure(lambda result: result == result.lower())
 def snake_case(identifier: str) -> str:
     """
     Convert an indentifier to a lowercase snake case.


### PR DESCRIPTION
@mristin 

I changed the postconditions as they were failing on non-alphanumeric input; for instance if the endpoint path is "/", the previous postcondition of `snake_case` wouldn't hold.