### PR TITLE
removed starting verb check for endpoint response descriptions

### DIFF
--- a/swagger_to/style.py
+++ b/swagger_to/style.py
@@ -133,26 +133,26 @@ def _check_descriptions_endpoints(endpoints: List[swagger_to.intermediate.Endpoi
     complaints = []  # type: List[Complaint]
 
     for endpoint in endpoints:
-        if _check_description(endpoint.description, True):
+        if _check_description(description=endpoint.description, starts_with_verb=True):
             complaints.append(
                 Complaint(
-                    message=_check_description(endpoint.description, True),
+                    message=_check_description(description=endpoint.description, starts_with_verb=True),
                     what=endpoint.description,
                     where="In endpoint {}".format(endpoint.operation_id),
                     line=endpoint.line))
         for param in endpoint.parameters:
-            if _check_description(param.description, True):
+            if _check_description(description=param.description, starts_with_verb=True):
                 complaints.append(
                     Complaint(
-                        message=_check_description(param.description, True),
+                        message=_check_description(description=param.description, starts_with_verb=True),
                         what=param.description,
                         where="In endpoint {}, parameter {}".format(endpoint.operation_id, param.name),
                         line=param.line))
         for _, resp in enumerate(endpoint.responses.values()):
-            if _check_description(resp.description, False):
+            if _check_description(description=resp.description, starts_with_verb=False):
                 complaints.append(
                     Complaint(
-                        message=_check_description(resp.description, False),
+                        message=_check_description(description=resp.description, starts_with_verb=False),
                         what=resp.description,
                         where="In endpoint {}, response {}".format(endpoint.operation_id, resp.code),
                         line=resp.line))
@@ -240,40 +240,40 @@ def _check_recursively_descriptions(typedef: swagger_to.intermediate.Typedef,
         pass
 
     elif isinstance(typedef, swagger_to.intermediate.Arraydef):
-        if _check_description(typedef.description, True):
+        if _check_description(description=typedef.description, starts_with_verb=True):
             complaints.append(
                 Complaint(
-                    message=_check_description(typedef.description, True),
+                    message=_check_description(description=typedef.description, starts_with_verb=True),
                     what=typedef.description,
                     where="In array {}".format(typedef.identifier),
                     line=typedef.line))
         complaints.extend(_check_recursively_descriptions(typedef=typedef.items, visited=visited))
 
     elif isinstance(typedef, swagger_to.intermediate.Mapdef):
-        if _check_description(typedef.description, True):
+        if _check_description(description=typedef.description, starts_with_verb=True):
             complaints.append(
                 Complaint(
                     what=typedef.description,
-                    message=_check_description(typedef.description, True),
+                    message=_check_description(description=typedef.description, starts_with_verb=True),
                     where="In map {}".format(typedef.identifier),
                     line=typedef.line))
         complaints.extend(_check_recursively_descriptions(typedef=typedef.values, visited=visited))
 
     elif isinstance(typedef, swagger_to.intermediate.Objectdef):
-        if _check_description(typedef.description, True):
+        if _check_description(description=typedef.description, starts_with_verb=True):
             complaints.append(
                 Complaint(
                     what=typedef.description,
-                    message=_check_description(typedef.description, True),
+                    message=_check_description(description=typedef.description, starts_with_verb=True),
                     where="In object {}".format(typedef.identifier),
                     line=typedef.line))
 
         for prop in typedef.properties.values():
-            if _check_description(prop.description, True):
+            if _check_description(description=prop.description, starts_with_verb=True):
                 complaints.append(
                     Complaint(
                         what=prop.description,
-                        message=_check_description(prop.description, True),
+                        message=_check_description(description=prop.description, starts_with_verb=True),
                         where="In object {}, property {}".format(typedef.identifier, prop.name),
                         line=typedef.line))
                 complaints.extend(_check_recursively_descriptions(typedef=prop.typedef, visited=visited))
@@ -330,32 +330,31 @@ def _check_endpoint_path(endpoints: List[swagger_to.intermediate.Endpoint]) -> L
     return complaints
 
 
-def _check_description(description: str, starting_verb_check: bool) -> Optional[str]:
+def _check_description(description: str, starts_with_verb: bool) -> Optional[str]:
     """
     Check whether a description is well-styled.
 
     :param description: the description
-    :param starting_verb_check: if true, the description should start with a verb in third person singular (stem -s)
+    :param starts_with_verb:
+        if True, check that the description should start with a verb in third person singular (stem -s).
     :return: the failed check, if any
     """
     # pylint: disable=too-many-return-statements, too-many-branches
     if description == "":
         return None
 
-    without_pipe = description.replace("|", "")
-
-    if not without_pipe[:1].isalpha():
+    if not description[:1].isalpha():
         return "description should start with alphanumeric character"
 
-    if without_pipe[:1].isupper():
+    if description[:1].isupper():
         return "description should start with lower case character"
 
-    words = without_pipe.split(' ')
+    words = description.split(' ')
 
-    if starting_verb_check and not words[0].endswith('s'):
+    if starts_with_verb and not words[0].endswith('s'):
         return "description should start with verb in present tense (stem + \"-s\")"
 
-    lines = without_pipe.splitlines()
+    lines = description.splitlines()
 
     if not lines[0].endswith('.'):
         return "description's first line should end with a period"
@@ -376,7 +375,7 @@ def _check_description(description: str, starting_verb_check: bool) -> Optional[
         else:
             one_empty_line = False
 
-    if without_pipe.strip() != without_pipe:
+    if description.strip() != description:
         return "description should not contain leading or trailing whitespaces"
 
     return None

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -66,29 +66,49 @@ class TestStyleCheck(unittest.TestCase):
 class TestDescription(unittest.TestCase):
     def test_that_it_works(self):
         # Good: empty string
-        self.assertEqual(swagger_to.style._check_description("", True), None)
+        self.assertEqual(swagger_to.style._check_description(description="", starts_with_verb=True), None)
         # Good: lower case first letter and ends with period
-        self.assertEqual(swagger_to.style._check_description("is a well-formatted description.", True), None)
+        self.assertEqual(
+            swagger_to.style._check_description(description="is a well-formatted description.", starts_with_verb=True),
+            None)
         # Good: description and paragraph
         self.assertEqual(
-            swagger_to.style._check_description("is a well-formatted description.\n\nit really is a "
-                                                "well-formatted thing", True), None)
+            swagger_to.style._check_description(
+                description="is a well-formatted description.\n\nit really is a "
+                "well-formatted thing",
+                starts_with_verb=True), None)
         # Good: description and paragraphs
         self.assertEqual(
-            swagger_to.style._check_description("is a well-formatted description.\n\nit really is a "
-                                                "well-formatted thing\n\nit really is", True), None)
+            swagger_to.style._check_description(
+                description="is a well-formatted description.\n\nit really is a "
+                "well-formatted thing\n\nit really is",
+                starts_with_verb=True), None)
 
         # Bad: everything else
-        self.assertNotEqual(swagger_to.style._check_description("isnt a not-so-well-formatted description", True), None)
-        self.assertNotEqual(swagger_to.style._check_description("Has a not-so-well-formatted description.", True), None)
-        self.assertNotEqual(swagger_to.style._check_description("has a not-so-well-formatted description", True), None)
-        self.assertNotEqual(swagger_to.style._check_description("123e1dt-so-well-formatted description.", True), None)
         self.assertNotEqual(
-            swagger_to.style._check_description("    is not-so-well-formatted description.", True), None)
-        self.assertNotEqual(swagger_to.style._check_description("\tis not-so-well-formatted description.", True), None)
-        self.assertNotEqual(swagger_to.style._check_description("\nis not-so-well-formatted description.", True), None)
+            swagger_to.style._check_description(
+                description="isnt a not-so-well-formatted description", starts_with_verb=True), None)
         self.assertNotEqual(
-            swagger_to.style._check_description("is not-so-well-formatted description.\nnot at all.", True), None)
+            swagger_to.style._check_description(
+                description="Has a not-so-well-formatted description.", starts_with_verb=True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description(
+                description="has a not-so-well-formatted description", starts_with_verb=True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description(
+                description="123e1dt-so-well-formatted description.", starts_with_verb=True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description(
+                description="    is not-so-well-formatted description.", starts_with_verb=True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description(
+                description="\tis not-so-well-formatted description.", starts_with_verb=True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description(
+                description="\nis not-so-well-formatted description.", starts_with_verb=True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description(
+                description="is not-so-well-formatted description.\nnot at all.", starts_with_verb=True), None)
 
 
 if __name__ == '__main__':

--- a/tests/test_style.py
+++ b/tests/test_style.py
@@ -66,28 +66,29 @@ class TestStyleCheck(unittest.TestCase):
 class TestDescription(unittest.TestCase):
     def test_that_it_works(self):
         # Good: empty string
-        self.assertEqual(swagger_to.style._check_description(""), None)
+        self.assertEqual(swagger_to.style._check_description("", True), None)
         # Good: lower case first letter and ends with period
-        self.assertEqual(swagger_to.style._check_description("is a well-formatted description."), None)
+        self.assertEqual(swagger_to.style._check_description("is a well-formatted description.", True), None)
         # Good: description and paragraph
         self.assertEqual(
             swagger_to.style._check_description("is a well-formatted description.\n\nit really is a "
-                                                "well-formatted thing"), None)
+                                                "well-formatted thing", True), None)
         # Good: description and paragraphs
         self.assertEqual(
             swagger_to.style._check_description("is a well-formatted description.\n\nit really is a "
-                                                "well-formatted thing\n\nit really is"), None)
+                                                "well-formatted thing\n\nit really is", True), None)
 
         # Bad: everything else
-        self.assertNotEqual(swagger_to.style._check_description("isnt a not-so-well-formatted description"), None)
-        self.assertNotEqual(swagger_to.style._check_description("Has a not-so-well-formatted description."), None)
-        self.assertNotEqual(swagger_to.style._check_description("has a not-so-well-formatted description"), None)
-        self.assertNotEqual(swagger_to.style._check_description("123e1dt-so-well-formatted description."), None)
-        self.assertNotEqual(swagger_to.style._check_description("    is not-so-well-formatted description."), None)
-        self.assertNotEqual(swagger_to.style._check_description("\tis not-so-well-formatted description."), None)
-        self.assertNotEqual(swagger_to.style._check_description("\nis not-so-well-formatted description."), None)
+        self.assertNotEqual(swagger_to.style._check_description("isnt a not-so-well-formatted description", True), None)
+        self.assertNotEqual(swagger_to.style._check_description("Has a not-so-well-formatted description.", True), None)
+        self.assertNotEqual(swagger_to.style._check_description("has a not-so-well-formatted description", True), None)
+        self.assertNotEqual(swagger_to.style._check_description("123e1dt-so-well-formatted description.", True), None)
         self.assertNotEqual(
-            swagger_to.style._check_description("is not-so-well-formatted description.\nnot at all."), None)
+            swagger_to.style._check_description("    is not-so-well-formatted description.", True), None)
+        self.assertNotEqual(swagger_to.style._check_description("\tis not-so-well-formatted description.", True), None)
+        self.assertNotEqual(swagger_to.style._check_description("\nis not-so-well-formatted description.", True), None)
+        self.assertNotEqual(
+            swagger_to.style._check_description("is not-so-well-formatted description.\nnot at all.", True), None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@mristin 

I'm not sure you're gonna like this solution with the flag for starting_verb_check, but writing a whole different function just to check endpoint responses and have it 96% identical to the already existing one seemed to me like a greater evil. Perhaps you have a third solution in mind?