### PR TITLE
made py client more robust to parameter names

### DIFF
--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -274,7 +274,6 @@ def _to_response(intermediate_response: swagger_to.intermediate.Response,
     resp.description = intermediate_response.description
     return resp
 
-
 @icontract.ensure(
     lambda result:
     sorted(result.parameters, key=id) == sorted([
@@ -304,6 +303,11 @@ def _to_request(endpoint: swagger_to.intermediate.Endpoint, typedefs: MutableMap
     ##
     # Generate identifiers corresponding to the parameters.
     ##
+
+    for intermediate_param in endpoint.parameters:
+        if intermediate_param.name == "":
+            raise ValueError("Unexpected empty intermediate parameter name in the endpoint: {}".format(
+                endpoint.operation_id))
 
     param_to_identifier = {
         intermediate_param: swagger_to.snake_case(identifier=intermediate_param.name)

--- a/swagger_to/swagger.py
+++ b/swagger_to/swagger.py
@@ -365,10 +365,6 @@ def parse_yaml(stream: Any) -> Tuple[Swagger, List[str]]:
 
         ordered_hook = object_pairs_hook(mapping)
 
-        # assert not hasattr(ordered_hook, "__lineno__"), \
-        #     "Expected ordered mapping to have no __lineno__ attribute set before"
-        # setattr(ordered_hook, "__lineno__", node.__lineno__)
-
         return RawDict(adict=ordered_hook, source=stream.name, lineno=node.__lineno__)
 
     OrderedLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, construct_mapping)


### PR DESCRIPTION
The parameter names such as '_fields' broke the py client since the
snake casing got confused by the prefix underscore. This patch fixes
both snake casing and camel casing to handle such identifiers.