### PR TITLE
fixed JSON Pointer representation rule

### DIFF
--- a/swagger_to/intermediate.py
+++ b/swagger_to/intermediate.py
@@ -463,13 +463,13 @@ def to_parameters(swagger: swagger_to.swagger.Swagger,
     """
     params = collections.OrderedDict()  # type: MutableMapping[str, Parameter]
 
-    for original_param in swagger.parameters.values():
+    for key, original_param in swagger.parameters.items():
         if original_param.ref != '':
             raise ValueError("Expected no 'ref' property in a parameter definition {!r}, but got: {!r}".format(
                 original_param.name, original_param.raw_dict.adict if original_param.raw_dict is not None else None))
 
         param = _to_parameter(original_param=original_param, typedefs=typedefs)
-        params[param.name] = param
+        params[key] = param
 
     return params
 

--- a/tests/cases/py_client/referenced_parameter/client.py
+++ b/tests/cases/py_client/referenced_parameter/client.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!
+"""Implements the client for test."""
+
+# pylint: skip-file
+# pydocstyle: add-ignore=D105,D107,D401
+
+import contextlib
+import json
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+
+import requests
+import requests.auth
+
+
+class RemoteCaller:
+    """Executes the remote calls to the server."""
+
+    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+        self.url_prefix = url_prefix
+        self.auth = auth
+
+    def test_me(
+            self,
+            some_parameter: str,
+            some_optional: Optional[str] = None,
+            same_named: Optional[str] = None) -> bytes:
+        """
+        Is a test endpoint.
+
+        :param some_parameter:
+        :param some_optional:
+        :param same_named:
+
+        :return: a confirmation
+        """
+        url = self.url_prefix + '/products'
+
+        headers = {}  # type: Dict[str, str]
+
+        headers['Some-parameter'] = some_parameter
+
+        if some_optional is not None:
+            headers['Some-optional'] = some_optional
+
+        if same_named is not None:
+            headers['same_named'] = same_named
+
+        resp = requests.request(
+            method='get',
+            url=url,
+            headers=headers,
+            auth=self.auth)
+
+        with contextlib.closing(resp):
+            resp.raise_for_status()
+            return resp.content
+
+
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/py_client/referenced_parameter/swagger.yaml
+++ b/tests/cases/py_client/referenced_parameter/swagger.yaml
@@ -1,0 +1,42 @@
+swagger: '2.0'
+info:
+  title: Dummy Test API
+  description: Test code generation.
+  version: 1.0.0
+schemes:
+  - https
+basePath: /
+tags:
+  - name: test
+paths:
+  /products:
+    get:
+      operationId: test_me
+      tags:
+        - test
+      description: is a test endpoint.
+      parameters:
+        - $ref: '#/parameters/SomeParameter'
+        - $ref: '#/parameters/some_optional'
+        - $ref: '#/parameters/same_name'
+      responses:
+        200:
+          description: a confirmation
+        default:
+          description: Unexpected error
+parameters:
+  SomeParameter:
+    name: Some-parameter
+    in: header
+    type: string
+    required: true
+  some_optional:
+    name: Some-optional
+    in: header
+    type: string
+    required: false
+  same_name:
+    name: same_named
+    in: header
+    type: string
+    required: false


### PR DESCRIPTION
Can not resolve parameter object of 'ref' and 'name' are different.

The OAS2 Spec uses a JSON Pointer, so this has been fixed.
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#referenceObject