### PR TITLE
BinaryIO response supported in python client

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -193,7 +193,7 @@ def main() -> int:
     futures_paths = []  # type: List[Tuple[concurrent.futures.Future, pathlib.Path]]
     with concurrent.futures.ThreadPoolExecutor() as executor:
         for pth in pending_pths:
-            future = executor.submit(fn=check, path=pth, py_dir=py_dir, overwrite=overwrite)
+            future = executor.submit(check, path=pth, py_dir=py_dir, overwrite=overwrite)
             futures_paths.append((future, pth))
 
         for future, pth in futures_paths:

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,15 @@ setup(
     keywords='swagger code generation python elm go typescript server client angular',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=['pyyaml>=3.12', 'jinja2>=2.10,<3', 'icontract>=2.0.1,<3'],
-    extras_require={'dev': [
-        'mypy==0.782',
-        'pylint==2.5.3',
-        'yapf==0.20.2',
-        'pydocstyle>=3.0.0,<4',
-        'requests_mock>=1.8.0'
-    ]},
+    extras_require={
+        'dev': [
+            'mypy==0.782',
+            'pylint==2.5.3',
+            'yapf==0.20.2',
+            'pydocstyle>=3.0.0,<4',
+            'requests_mock>=1.8.0',
+        ],
+    },
     py_modules=['swagger_to'],
     package_data={"swagger_to": ["py.typed"]},
     scripts=[

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'pylint==2.5.3',
         'yapf==0.20.2',
         'pydocstyle>=3.0.0,<4',
+        'requests_mock>=1.8.0'
     ]},
     py_modules=['swagger_to'],
     package_data={"swagger_to": ["py.typed"]},

--- a/tests/cases/py_client/date_time_property/client.py
+++ b/tests/cases/py_client/date_time_property/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -233,7 +233,8 @@ class RemoteCaller:
             method='get',
             url=url,
             json=data,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/empty_schema/client.py
+++ b/tests/cases/py_client/empty_schema/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -291,7 +291,8 @@ class RemoteCaller:
             method='get',
             url=url,
             json=data,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/file_stream/client.py
+++ b/tests/cases/py_client/file_stream/client.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!
+"""Implements the client for test_server."""
+
+# pylint: skip-file
+# pydocstyle: add-ignore=D105,D107,D401
+
+import contextlib
+import json
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+
+import requests
+import requests.auth
+
+from typing import cast
+from http.client import HTTPResponse
+
+import urllib3
+
+
+class _WrappedResponse(urllib3.HTTPResponse):
+    # noinspection PyMissingConstructor
+    def __init__(self, response: requests.Response):
+        self._response = response
+
+    def __getattr__(self, item):
+        return getattr(self._response.raw, item)
+
+    def close(self):
+        self._response.close()
+
+
+def _wrap_response(resp: requests.Response) -> HTTPResponse:
+    """
+    Wrap HTTPResponse object.
+    """
+
+    # urllib3.HTTPResponse has compatible interface of standard http lib. 
+    # (see docs for urllib3.HTTPResponse)
+    return cast(HTTPResponse, _WrappedResponse(resp))
+
+
+class RemoteCaller:
+    """Executes the remote calls to the server."""
+
+    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+        self.url_prefix = url_prefix
+        self.auth = auth
+
+    def open_file(
+            self,
+            path: str) -> BinaryIO:
+        """
+        Serves a static file that matches the path.
+
+        :param path: is the path to the file relative to the root.
+
+        :return: serves the file content.
+        """
+        url = "".join([
+            self.url_prefix,
+            '/',
+            str(path)])
+
+        resp = requests.request(
+            method='get',
+            url=url,
+            auth=self.auth,
+            stream=True,
+        )
+
+        resp.raise_for_status()
+        return _wrap_response(resp)
+
+
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/py_client/file_stream/client.py
+++ b/tests/cases/py_client/file_stream/client.py
@@ -7,12 +7,11 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
 
-from typing import cast
 from http.client import HTTPResponse
 
 import urllib3

--- a/tests/cases/py_client/file_stream/swagger.yaml
+++ b/tests/cases/py_client/file_stream/swagger.yaml
@@ -1,0 +1,31 @@
+swagger: '2.0'
+info:
+  title: Dummy Test API
+  description: Test code generation.
+  version: 1.0.0
+schemes:
+  - https
+basePath: /
+tags:
+  - name: test_server
+paths:
+  /{path}:
+    get:
+      operationId: open_file
+      tags:
+        - test_server
+      description: serves a static file that matches the path.
+      parameters:
+        - name: path
+          in: path
+          description: is the path to the file relative to the root.
+          required: true
+          type: string
+          pattern: .+
+      responses:
+        200:
+          description: serves the file content.
+          schema:
+            type: file
+        default:
+          description: contains an unexpected error.

--- a/tests/cases/py_client/file_stream/test.py
+++ b/tests/cases/py_client/file_stream/test.py
@@ -1,0 +1,37 @@
+import contextlib
+import unittest
+from urllib.parse import urljoin
+
+import requests_mock
+
+from .client import RemoteCaller
+
+url_prefix = "http://localhost"
+
+
+class MyTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.client = RemoteCaller(url_prefix)
+
+    def test_open_file(self):
+        file_name = "target"
+
+        content = b"""{"json_bytes": "value"}"""
+
+        with requests_mock.Mocker() as m:
+            # setup mock response
+            m.get(urljoin(url_prefix, file_name), content=content)
+
+            res = self.client.open_file(file_name)
+
+            self.assertFalse(res.closed)
+
+            with contextlib.closing(res):
+                loaded = res.read()
+                self.assertEqual(content, loaded)
+
+            self.assertTrue(res.closed)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cases/py_client/files/client.py
+++ b/tests/cases/py_client/files/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -47,7 +47,8 @@ class RemoteCaller:
             url=url,
             data=data,
             files=files,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -71,7 +72,8 @@ class RemoteCaller:
         resp = requests.request(
             method='get',
             url=url,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/general/client.py
+++ b/tests/cases/py_client/general/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -838,7 +838,8 @@ class RemoteCaller:
             method='get',
             url=url,
             params=params,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -886,7 +887,8 @@ class RemoteCaller:
             method='get',
             url=url,
             params=params,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -928,7 +930,8 @@ class RemoteCaller:
             method='get',
             url=url,
             params=params,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -957,7 +960,8 @@ class RemoteCaller:
             method='patch',
             url=url,
             json=data,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -997,7 +1001,8 @@ class RemoteCaller:
             url=url,
             data=data,
             files=files,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -1006,7 +1011,7 @@ class RemoteCaller:
     def history(
             self,
             offset: Optional[int] = None,
-            limit: Optional[int] = None) -> bytes:
+            limit: Optional[int] = None) -> Activities:
         """
         The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will
         include pickup locations and times, dropoff locations and times, the distance of past requests, and
@@ -1031,11 +1036,14 @@ class RemoteCaller:
             method='get',
             url=url,
             params=params,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()
-            return resp.content
+            return from_obj(
+                obj=resp.json(),
+                expected=[Activities])
 
 
 # Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/py_client/header_parameter/client.py
+++ b/tests/cases/py_client/header_parameter/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -49,7 +49,8 @@ class RemoteCaller:
             method='get',
             url=url,
             headers=headers,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/object_with_no_properties/client.py
+++ b/tests/cases/py_client/object_with_no_properties/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -210,7 +210,8 @@ class RemoteCaller:
             method='get',
             url=url,
             json=data,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/object_with_optional_properties/client.py
+++ b/tests/cases/py_client/object_with_optional_properties/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -251,7 +251,8 @@ class RemoteCaller:
             method='get',
             url=url,
             json=data,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/parameter_name_conflict/client.py
+++ b/tests/cases/py_client/parameter_name_conflict/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -45,7 +45,8 @@ class RemoteCaller:
             method='get',
             url=url,
             params=params,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/primitive_and_complex_form_data/client.py
+++ b/tests/cases/py_client/primitive_and_complex_form_data/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -258,7 +258,8 @@ class RemoteCaller:
             method='get',
             url=url,
             data=data,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/cases/py_client/referenced_parameter/client.py
+++ b/tests/cases/py_client/referenced_parameter/client.py
@@ -7,7 +7,7 @@
 
 import contextlib
 import json
-from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
 
 import requests
 import requests.auth
@@ -50,7 +50,8 @@ class RemoteCaller:
             method='get',
             url=url,
             headers=headers,
-            auth=self.auth)
+            auth=self.auth,
+        )
 
         with contextlib.closing(resp):
             resp.raise_for_status()

--- a/tests/test_py_client.py
+++ b/tests/test_py_client.py
@@ -74,5 +74,20 @@ class TestDocstring(unittest.TestCase):
         self.assertEqual('"""\nDo\nreally\nsomething.\n"""', result)
 
 
+# pylint: disable=unused-argument
+def load_tests(loader: unittest.TestLoader, suite: unittest.TestSuite, pattern):
+    tests_dir = pathlib.Path(os.path.realpath(__file__)).parent
+
+    cases_dir = tests_dir / "cases" / "py_client"
+
+    for case_dir in sorted(cases_dir.iterdir()):
+        for test_case in case_dir.glob("test*.py"):
+            mod_name = str(test_case.relative_to(tests_dir)).replace(".py", "").replace("/", ".")
+            tests = unittest.TestLoader().discover(mod_name, top_level_dir=str(tests_dir))
+            suite.addTests(tests)
+
+    return suite
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Supported to BinaryIO response in case of 'schema: file' or 'schema: string' with 'format: binary' to make large files available for download.
Besides, add a new mock based unit test for BinaryIO response.