### PR TITLE
bumped version to 4.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+4.0.0
+=====
+Breaking change:
+
+* made py-client give back streams on file responses
+
+Non-breaking changes:
+
+* added support for empty schema type (*i.e.* arbitrary type)
+* added boolean argument support in go-server
+* added "generated code" comment based on official format of golang
+* fixed indent of structs in go-server
+
 3.1.4
 =====
 * fixed JSON pointer representation.

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='swagger_to',
-    version='3.1.4',
+    version='4.0.0',
     description='Generate server and client code from Swagger (OpenAPI 2.0) specification',
     long_description=long_description,
     url='https://github.com/Parquery/swagger-to',


### PR DESCRIPTION
Breaking change:

* made py-client give back streams on file responses

Non-breaking changes:

* added support for empty schema type (*i.e.* arbitrary type)
* added boolean argument support in go-server
* added "generated code" comment based on official format of golang
* fixed indent of structs in go-server