### PR TITLE
dashes in operation IDs supported in py_client

### DIFF
--- a/tests/cases/py_client/operation_id_with_a_dash/client.py
+++ b/tests/cases/py_client/operation_id_with_a_dash/client.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!
+"""Implements the client for test."""
+
+# pylint: skip-file
+# pydocstyle: add-ignore=D105,D107,D401
+
+import contextlib
+import json
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
+
+import requests
+import requests.auth
+
+
+class RemoteCaller:
+    """Executes the remote calls to the server."""
+
+    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+        self.url_prefix = url_prefix
+        self.auth = auth
+
+    def test_me(self) -> bytes:
+        """
+        Is a test endpoint.
+
+        :return: a confirmation
+        """
+        url = self.url_prefix + '/test-me'
+
+        resp = requests.request(method='get', url=url, auth=self.auth)
+
+        with contextlib.closing(resp):
+            resp.raise_for_status()
+            return resp.content
+
+
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/py_client/operation_id_with_a_dash/swagger.yaml
+++ b/tests/cases/py_client/operation_id_with_a_dash/swagger.yaml
@@ -1,0 +1,22 @@
+swagger: '2.0'
+info:
+  title: Dummy Test API
+  description: Test code generation.
+  version: 1.0.0
+schemes:
+  - https
+basePath: /
+tags:
+  - name: test
+paths:
+  /test-me:
+    get:
+      operationId: test-me
+      tags:
+        - test
+      description: is a test endpoint.
+      responses:
+        200:
+          description: a confirmation
+        default:
+          description: Unexpected error


### PR DESCRIPTION
There are specs in the wild that use dashes in the operation IDs.
While uncommon, there is no reason why code generated by py_client
should not handle these cases correctly. This patch lets the function
names be determined by the snake case of the operation ID instead of
the vanilla value.

Fixes #88.