### PR TITLE
fixed py_client for operation IDs with dashes

### DIFF
--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -1112,7 +1112,7 @@ _REQUEST_FUNCTION_TPL = _from_string_with_informative_exceptions(
 def {{ function_name }}(self) -> {{ return_type }}:
 {% else %}
 {% set suffix = ') -> %s:'|format(return_type) %}
-def {{ request.operation_id}}(
+def {{ function_name }}(
         self,
         {% for param in request.parameters %}
         {% if not param.required %}

--- a/tests/cases/py_client/operation_id_with_a_dash/client.py
+++ b/tests/cases/py_client/operation_id_with_a_dash/client.py
@@ -34,5 +34,55 @@ class RemoteCaller:
             resp.raise_for_status()
             return resp.content
 
+    def post_test_another_one(
+            self,
+            id: str) -> bytes:
+        """
+        Is another test endpoint.
+
+        :param id:
+
+        :return: a confirmation
+        """
+        url = "".join([
+            self.url_prefix,
+            '/test-another-one/',
+            str(id)])
+
+        resp = requests.request(
+            method='post',
+            url=url,
+            auth=self.auth,
+        )
+
+        with contextlib.closing(resp):
+            resp.raise_for_status()
+            return resp.content
+
+    def delete_test_another_one(
+            self,
+            id: str) -> bytes:
+        """
+        Is yet another test endpoint.
+
+        :param id:
+
+        :return: a confirmation
+        """
+        url = "".join([
+            self.url_prefix,
+            '/test-another-one/',
+            str(id)])
+
+        resp = requests.request(
+            method='delete',
+            url=url,
+            auth=self.auth,
+        )
+
+        with contextlib.closing(resp):
+            resp.raise_for_status()
+            return resp.content
+
 
 # Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/py_client/operation_id_with_a_dash/swagger.yaml
+++ b/tests/cases/py_client/operation_id_with_a_dash/swagger.yaml
@@ -20,3 +20,38 @@ paths:
           description: a confirmation
         default:
           description: Unexpected error
+
+  /test-another-one/{id}:
+    post:
+      operationId: post-test-another-one
+      tags:
+        - test
+      description: is another test endpoint.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: a confirmation
+        default:
+          description: Unexpected error
+
+    delete:
+      operationId: delete-test-another-one
+      tags:
+        - test
+      description: is yet another test endpoint.
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: a confirmation
+        default:
+          description: Unexpected error


### PR DESCRIPTION
The test case used in pull request #89 was too narrow. When endpoints
require parameters, the function name was not properly generated (the
dashes were kept in the name).

The bug was due to the if-else branching where the proper function name
was set only in the if-branch.

Fixes #88.