### PR TITLE
made py_client accept custom requests.Session object

### DIFF
--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -1524,7 +1524,11 @@ def _wrap_response(resp: requests.Response) -> HTTPResponse:
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None, session: Optional[requests.Session] = None) -> None:
+    def __init__(
+        self, 
+        url_prefix: str, 
+        auth: Optional[requests.auth.AuthBase] = None, 
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
         self.session = session

--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -1246,9 +1246,9 @@ data[{{ param.name|repr }}] = json.dumps(
     {% endif %}{# /if request.file_parameters #}
 
     {% if not request.parameters %}
-    resp = requests.request(method={{ request.method|repr }}, url=url, auth=self.auth)
+    resp = self.session.request(method={{ request.method|repr }}, url=url)
     {% else %}
-    resp = requests.request(
+    resp = self.session.request(
         method={{ request.method|repr }},
         url=url,
         {% if request.header_parameters %}
@@ -1266,7 +1266,6 @@ data[{{ param.name|repr }}] = json.dumps(
         {% if request.file_parameters %}
         files=files,
         {% endif %}
-        auth=self.auth,
         {% if return_type == 'BinaryIO' %}
         stream=True,
         {% endif %}
@@ -1525,9 +1524,14 @@ def _wrap_response(resp: requests.Response) -> HTTPResponse:
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None, session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
     {% for request in requests %}
 
     {{ request_function[request]|indent }}

--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -1525,9 +1525,9 @@ class RemoteCaller:
     """Executes the remote calls to the server."""
 
     def __init__(
-        self, 
-        url_prefix: str, 
-        auth: Optional[requests.auth.AuthBase] = None, 
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
         session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth

--- a/tests/cases/py_client/date_time_property/client.py
+++ b/tests/cases/py_client/date_time_property/client.py
@@ -207,9 +207,18 @@ def test_object_to_jsonable(
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -229,11 +238,10 @@ class RemoteCaller:
                 test_object,
                 expected=[TestObject])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             json=data,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/empty_schema/client.py
+++ b/tests/cases/py_client/empty_schema/client.py
@@ -266,9 +266,18 @@ def with_empty_properties_to_jsonable(
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_endpoint(
             self,
@@ -287,11 +296,10 @@ class RemoteCaller:
             expected=[EmptyParameter])
 
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             json=data,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/file_stream/client.py
+++ b/tests/cases/py_client/file_stream/client.py
@@ -53,9 +53,18 @@ def _wrap_response(resp: requests.Response) -> HTTPResponse:
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def open_file(
             self,
@@ -72,10 +81,9 @@ class RemoteCaller:
             '/',
             str(path)])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
-            auth=self.auth,
             stream=True,
         )
 

--- a/tests/cases/py_client/files/client.py
+++ b/tests/cases/py_client/files/client.py
@@ -16,9 +16,18 @@ import requests.auth
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def upload(
             self,
@@ -42,12 +51,11 @@ class RemoteCaller:
 
         files['reference_image'] = reference_image
 
-        resp = requests.request(
+        resp = self.session.request(
             method='put',
             url=url,
             data=data,
             files=files,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -69,10 +77,9 @@ class RemoteCaller:
             '/',
             str(path)])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/general/client.py
+++ b/tests/cases/py_client/general/client.py
@@ -810,9 +810,18 @@ def activities_to_jsonable(
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def products(
             self,
@@ -834,11 +843,10 @@ class RemoteCaller:
 
         params['longitude'] = json.dumps(longitude)
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             params=params,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -883,11 +891,10 @@ class RemoteCaller:
         if max_lines is not None:
             params['max_lines'] = json.dumps(max_lines)
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             params=params,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -926,11 +933,10 @@ class RemoteCaller:
         if product_id is not None:
             params['product_id'] = product_id
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             params=params,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -956,11 +962,10 @@ class RemoteCaller:
             expected=[Profile])
 
 
-        resp = requests.request(
+        resp = self.session.request(
             method='patch',
             url=url,
             json=data,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -996,12 +1001,11 @@ class RemoteCaller:
 
         files['profile_picture'] = profile_picture
 
-        resp = requests.request(
+        resp = self.session.request(
             method='patch',
             url=url,
             data=data,
             files=files,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -1032,11 +1036,10 @@ class RemoteCaller:
         if limit is not None:
             params['limit'] = json.dumps(limit)
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             params=params,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/header_parameter/client.py
+++ b/tests/cases/py_client/header_parameter/client.py
@@ -16,9 +16,18 @@ import requests.auth
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -45,11 +54,10 @@ class RemoteCaller:
 
         headers['X-Some-Custom-Parameter'] = json.dumps(x_some_custom_parameter)
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             headers=headers,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/object_with_no_properties/client.py
+++ b/tests/cases/py_client/object_with_no_properties/client.py
@@ -184,9 +184,18 @@ def empty_object_to_jsonable(
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -206,11 +215,10 @@ class RemoteCaller:
                 empty_object,
                 expected=[EmptyObject])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             json=data,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/object_with_optional_properties/client.py
+++ b/tests/cases/py_client/object_with_optional_properties/client.py
@@ -225,9 +225,18 @@ def test_object_to_jsonable(
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -247,11 +256,10 @@ class RemoteCaller:
                 test_object,
                 expected=[TestObject])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             json=data,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/operation_id_with_a_dash/client.py
+++ b/tests/cases/py_client/operation_id_with_a_dash/client.py
@@ -16,9 +16,18 @@ import requests.auth
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(self) -> bytes:
         """
@@ -28,7 +37,7 @@ class RemoteCaller:
         """
         url = self.url_prefix + '/test-me'
 
-        resp = requests.request(method='get', url=url, auth=self.auth)
+        resp = self.session.request(method='get', url=url)
 
         with contextlib.closing(resp):
             resp.raise_for_status()
@@ -49,10 +58,9 @@ class RemoteCaller:
             '/test-another-one/',
             str(id)])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='post',
             url=url,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):
@@ -74,10 +82,9 @@ class RemoteCaller:
             '/test-another-one/',
             str(id)])
 
-        resp = requests.request(
+        resp = self.session.request(
             method='delete',
             url=url,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/parameter_name_conflict/client.py
+++ b/tests/cases/py_client/parameter_name_conflict/client.py
@@ -16,9 +16,18 @@ import requests.auth
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -41,11 +50,10 @@ class RemoteCaller:
 
         params['some_parameter'] = query_some_parameter
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             params=params,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/primitive_and_complex_form_data/client.py
+++ b/tests/cases/py_client/primitive_and_complex_form_data/client.py
@@ -221,9 +221,18 @@ def profile_to_jsonable(
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -254,11 +263,10 @@ class RemoteCaller:
         if some_int_parameter is not None:
             data['some_int_parameter'] = json.dumps(some_int_parameter)
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             data=data,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):

--- a/tests/cases/py_client/referenced_parameter/client.py
+++ b/tests/cases/py_client/referenced_parameter/client.py
@@ -16,9 +16,18 @@ import requests.auth
 class RemoteCaller:
     """Executes the remote calls to the server."""
 
-    def __init__(self, url_prefix: str, auth: Optional[requests.auth.AuthBase] = None) -> None:
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
         self.url_prefix = url_prefix
         self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
 
     def test_me(
             self,
@@ -46,11 +55,10 @@ class RemoteCaller:
         if same_named is not None:
             headers['same_named'] = same_named
 
-        resp = requests.request(
+        resp = self.session.request(
             method='get',
             url=url,
             headers=headers,
-            auth=self.auth,
         )
 
         with contextlib.closing(resp):


### PR DESCRIPTION
This change introduces a new optional `session` parameter to the
`py_client.RemoteCaller` constructor, allowing users to pass a custom
python-requests `Session` object.

Fixes #90.