### PR TITLE
made checks run on push and pull request events

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -1,0 +1,26 @@
+name: Check-pull-request
+
+on: [pull_request]
+
+jobs:
+  Execute:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.5, 3.6, 3.7, 3.8]
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install -e .[dev]
+
+      - name: Run checks
+        run: ./precommit.py

--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -1,6 +1,9 @@
-name: Check
+name: Check-push
 
-on: [push]
+on: 
+  push:
+    branches:
+      - master
 
 jobs:
   Execute:

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Swagger-to
 ==========
 
-.. image:: https://github.com/Parquery/swagger-to/workflows/Check/badge.svg
-    :target: https://github.com/Parquery/swagger-to/actions?query=workflow%3ACheck
+.. image:: https://github.com/Parquery/swagger-to/workflows/Check-push/badge.svg
+    :target: https://github.com/Parquery/swagger-to/actions?query=workflow%3ACheck-push
     :alt: Check status
 
 .. image:: https://badge.fury.io/py/swagger-to.svg


### PR DESCRIPTION
Currently, the workflow check was only executed on `push`
GitHub events. This patch makes the pre-commit checks run also on
pull requests since otherwise they are not performed on the forked
repositories.