### PR TITLE
made precommit checks run on Windows

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -211,11 +211,13 @@ def main() -> int:
     env = os.environ.copy()
     env['ICONTRACT_SLOW'] = 'true'
 
-    retcode = subprocess.call(['python3', '-m', 'unittest', 'discover', str(source_dir / 'tests')], env=env)
-    success = success and retcode == 0
+    retcode = subprocess.call([sys.executable, '-m', 'unittest', 'discover', str(source_dir / 'tests')], env=env)
+    if retcode != 0:
+        print("Unit tests failed.")
+        success = False
 
     if not success:
-        print("One or more checks failed.")
+        print("One or more checks failed, please see above.")
         return 1
 
     return 0

--- a/tests/test_py_client.py
+++ b/tests/test_py_client.py
@@ -45,6 +45,7 @@ class TestPyClient(unittest.TestCase):
 
             expected_pth = case_dir / "client.py"
             expected = expected_pth.read_text()
+
             self.assertEqual(expected, text)
 
 
@@ -82,7 +83,7 @@ def load_tests(loader: unittest.TestLoader, suite: unittest.TestSuite, pattern):
 
     for case_dir in sorted(cases_dir.iterdir()):
         for test_case in case_dir.glob("test*.py"):
-            mod_name = str(test_case.relative_to(tests_dir)).replace(".py", "").replace("/", ".")
+            mod_name = str(test_case.relative_to(tests_dir)).replace(".py", "").replace(os.sep, ".")
             tests = unittest.TestLoader().discover(mod_name, top_level_dir=str(tests_dir))
             suite.addTests(tests)
 


### PR DESCRIPTION
This patch fixes the precommit checks so that they not only run on
Linux, but on Windows as well. Swagger-to can be now developed on
Windows platform.