### PR TITLE
made py_client use `get` for optionals

### DIFF
--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -872,21 +872,22 @@ def {{ classdef.identifier|snake_case }}_from_obj(obj: Any, path: str = "") -> {
         obj[{{ attr.name|repr }}],
         expected=[{{ expected_type_expression[attr] }}],
         path=path + {{ '.%s'|format(attr.name)|repr }})  # type: {{ type_expression[attr] }}
-    {% else %}
+    {% else %}{# if attr in expected_type_expression #}
     {{ attr.name }}_from_obj = obj[{{ attr.name|repr }}]
     {% endif %}{# /if attr in expected_type_expression #}
-    {% else %}
-    if {{ attr.name|repr }} in obj:
+    {% else %}{# if attr.required #}
     {% if attr in expected_type_expression %}
+    obj_{{ attr.name }} = obj.get({{ attr.name|repr }}, None)
+    if obj_{{ attr.name }} is not None:
         {{ attr.name }}_from_obj = from_obj(
-            obj[{{ attr.name|repr }}],
+            obj_{{ attr.name }},
             expected=[{{ expected_type_expression[attr] }}],
             path=path + {{ '.%s'|format(attr.name)|repr }})  # type: Optional[{{ type_expression[attr] }}]
-    {% else %}
-        {{ attr.name }}_from_obj = obj[{{ attr.name|repr }}]
-    {% endif %}{# /if attr in expected_type_expression #}
     else:
         {{ attr.name }}_from_obj = None
+    {% else %}{# if attr in expected_type_expression #}
+    {{ attr.name }}_from_obj = obj.get({{ attr.name|repr }}, None)
+    {% endif %}{# /if attr in expected_type_expression #}
     {% endif %}{# /if attr.required #}
     {% endfor %}{# /for attr in classdef.attributes.values() #}
 

--- a/tests/cases/py_client/empty_schema/client.py
+++ b/tests/cases/py_client/empty_schema/client.py
@@ -233,10 +233,7 @@ def with_empty_properties_from_obj(obj: Any, path: str = "") -> WithEmptyPropert
 
     required_empty_property_from_obj = obj['required_empty_property']
 
-    if 'optional_empty_property' in obj:
-        optional_empty_property_from_obj = obj['optional_empty_property']
-    else:
-        optional_empty_property_from_obj = None
+    optional_empty_property_from_obj = obj.get('optional_empty_property', None)
 
     return WithEmptyProperties(
         required_empty_property=required_empty_property_from_obj,

--- a/tests/cases/py_client/general/client.py
+++ b/tests/cases/py_client/general/client.py
@@ -447,25 +447,28 @@ def price_estimate_from_obj(obj: Any, path: str = "") -> PriceEstimate:
         expected=[str],
         path=path + '.estimate')  # type: str
 
-    if 'low_estimate' in obj:
+    obj_low_estimate = obj.get('low_estimate', None)
+    if obj_low_estimate is not None:
         low_estimate_from_obj = from_obj(
-            obj['low_estimate'],
+            obj_low_estimate,
             expected=[float],
             path=path + '.low_estimate')  # type: Optional[float]
     else:
         low_estimate_from_obj = None
 
-    if 'high_estimate' in obj:
+    obj_high_estimate = obj.get('high_estimate', None)
+    if obj_high_estimate is not None:
         high_estimate_from_obj = from_obj(
-            obj['high_estimate'],
+            obj_high_estimate,
             expected=[float],
             path=path + '.high_estimate')  # type: Optional[float]
     else:
         high_estimate_from_obj = None
 
-    if 'surge_multiplier' in obj:
+    obj_surge_multiplier = obj.get('surge_multiplier', None)
+    if obj_surge_multiplier is not None:
         surge_multiplier_from_obj = from_obj(
-            obj['surge_multiplier'],
+            obj_surge_multiplier,
             expected=[float],
             path=path + '.surge_multiplier')  # type: Optional[float]
     else:
@@ -585,17 +588,19 @@ def profile_from_obj(obj: Any, path: str = "") -> Profile:
         expected=[str],
         path=path + '.picture')  # type: str
 
-    if 'first_name' in obj:
+    obj_first_name = obj.get('first_name', None)
+    if obj_first_name is not None:
         first_name_from_obj = from_obj(
-            obj['first_name'],
+            obj_first_name,
             expected=[str],
             path=path + '.first_name')  # type: Optional[str]
     else:
         first_name_from_obj = None
 
-    if 'promo_code' in obj:
+    obj_promo_code = obj.get('promo_code', None)
+    if obj_promo_code is not None:
         promo_code_from_obj = from_obj(
-            obj['promo_code'],
+            obj_promo_code,
             expected=[str],
             path=path + '.promo_code')  # type: Optional[str]
     else:

--- a/tests/cases/py_client/object_with_optional_properties/client.py
+++ b/tests/cases/py_client/object_with_optional_properties/client.py
@@ -180,17 +180,19 @@ def test_object_from_obj(obj: Any, path: str = "") -> TestObject:
             raise ValueError(
                 'Expected a key of type str at path {}, but got: {}'.format(path, type(key)))
 
-    if 'product_id' in obj:
+    obj_product_id = obj.get('product_id', None)
+    if obj_product_id is not None:
         product_id_from_obj = from_obj(
-            obj['product_id'],
+            obj_product_id,
             expected=[str],
             path=path + '.product_id')  # type: Optional[str]
     else:
         product_id_from_obj = None
 
-    if 'capacity' in obj:
+    obj_capacity = obj.get('capacity', None)
+    if obj_capacity is not None:
         capacity_from_obj = from_obj(
-            obj['capacity'],
+            obj_capacity,
             expected=[int],
             path=path + '.capacity')  # type: Optional[int]
     else:

--- a/tests/cases/py_client/object_with_optional_properties/test.py
+++ b/tests/cases/py_client/object_with_optional_properties/test.py
@@ -1,0 +1,26 @@
+import unittest
+
+from .client import test_object_from_obj
+
+
+class TestFromObj(unittest.TestCase):
+    def test_no_field_specified(self) -> None:
+        test_obj = test_object_from_obj(obj=dict())
+        self.assertIsNone(test_obj.product_id)
+        self.assertIsNone(test_obj.capacity)
+
+    def test_all_fields_specified(self) -> None:
+        test_obj = test_object_from_obj(
+            obj={"product_id": "some-product", "capacity": 3})
+        self.assertEqual("some-product", test_obj.product_id)
+        self.assertEqual(3, test_obj.capacity)
+
+    def test_all_fields_None(self) -> None:
+        test_obj = test_object_from_obj(
+            obj={"product_id": None, "capacity": None})
+        self.assertIsNone(test_obj.product_id)
+        self.assertIsNone(test_obj.capacity)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/cases/py_client/primitive_and_complex_form_data/client.py
+++ b/tests/cases/py_client/primitive_and_complex_form_data/client.py
@@ -185,9 +185,10 @@ def profile_from_obj(obj: Any, path: str = "") -> Profile:
         expected=[str],
         path=path + '.last_name')  # type: str
 
-    if 'first_name' in obj:
+    obj_first_name = obj.get('first_name', None)
+    if obj_first_name is not None:
         first_name_from_obj = from_obj(
-            obj['first_name'],
+            obj_first_name,
             expected=[str],
             path=path + '.first_name')  # type: Optional[str]
     else:


### PR DESCRIPTION
If an attribute of an object was set to `None`, `py_client` erroneously
tried to parse it since only the containment was checked for. This patch
fixes `py_client`'s behavior by using `get()` with the default value
`None`.

Fixes #95.