### PR TITLE
Support common parameters in path

### DIFF
--- a/swagger_to/intermediate.py
+++ b/swagger_to/intermediate.py
@@ -573,7 +573,10 @@ def _to_endpoint(method: swagger_to.swagger.Method, typedefs: MutableMapping[str
     endpt.produces = method.produces
     endpt.line = method.__lineno__
 
-    for original_param in method.parameters:
+    # We need to join method parameters with the path's common parameters.
+    # See https://swagger.io/docs/specification/2-0/describing-parameters/,
+    # Section "Common Parameters"
+    for original_param in method.parameters + method.path.parameters:
         param = _anonymous_or_get_parameter(original_param=original_param, typedefs=typedefs, params=params)
 
         if param.in_what == 'body':

--- a/tests/cases/elm_client/common_parameters/Client.elm
+++ b/tests/cases/elm_client/common_parameters/Client.elm
@@ -1,0 +1,42 @@
+-- Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!
+
+
+module Client 
+    exposing
+        ( getFooRequest
+        )
+
+import Dict exposing (Dict)
+import Http
+import Json.Decode
+import Json.Decode.Pipeline
+import Json.Encode
+import Json.Encode.Extra
+import Time
+
+
+-- Remote Calls
+
+
+
+{-| Contains a "get" request to the endpoint: `/api/v1/foo/{foo_id}`, to be sent with Http.send
+-}
+getFooRequest : String -> Maybe Time.Time -> Bool -> String -> Http.Request String
+getFooRequest prefix maybeTimeout withCredentials fooID =
+    let
+        url = prefix
+            ++ "api/v1/foo/"
+            ++ fooID    in
+    Http.request
+        { body = Http.emptyBody
+        , expect = Http.expectString
+        , headers = []
+        , method = "GET"
+        , timeout = maybeTimeout
+        , url = url
+        , withCredentials = withCredentials
+        }
+
+
+
+-- Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/elm_client/common_parameters/elm-package.json
+++ b/tests/cases/elm_client/common_parameters/elm-package.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.1.0",
+  "summary": "",
+  "repository": "https://github.com/invalid/repo.git",
+  "license": "",
+  "source-directories": [
+    "src"
+  ],
+  "exposed-modules": [],
+  "dependencies": {
+    "elm-lang/core": "2.0.0 <= v <= 2.0.0",
+    "elm-lang/http": "1.0.0 <= v <= 1.0.0",
+    "elm-community/json-extra": "2.7.0 <= v <= 2.7.0",
+    "NoRedInk/elm-decode-pipeline": "3.0.0 <= v <= 3.0.0"
+  },
+  "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/tests/cases/elm_client/common_parameters/swagger.yaml
+++ b/tests/cases/elm_client/common_parameters/swagger.yaml
@@ -1,0 +1,30 @@
+# This is a valid schema, but it broke swagger-to.
+# Please see the issue: https://github.com/Parquery/swagger-to/issues/68
+basePath: /api/v1
+consumes:
+- application/json
+info:
+  description: An API
+  title: An API
+  version: '1.0'
+paths:
+  /foo/{foo_id}:
+    get:
+      operationId: get_foo
+      responses:
+        '200':
+          description: Success
+      tags:
+      - foo
+    parameters:
+    - in: path
+      description: The foo id
+      name: foo_id
+      required: true
+      type: string
+produces:
+- application/json
+swagger: '2.0'
+tags:
+- description: description
+  name: foo

--- a/tests/cases/parsing/common_parameters/swagger.yaml
+++ b/tests/cases/parsing/common_parameters/swagger.yaml
@@ -1,0 +1,30 @@
+# This is a valid schema, but it broke swagger-to.
+# Please see the issue: https://github.com/Parquery/swagger-to/issues/68
+basePath: /api/v1
+consumes:
+- application/json
+info:
+  description: An API
+  title: An API
+  version: '1.0'
+paths:
+  /foo/{foo_id}:
+    get:
+      operationId: get_foo
+      responses:
+        '200':
+          description: Success
+      tags:
+      - foo
+    parameters:
+    - in: path
+      description: The foo id
+      name: foo_id
+      required: true
+      type: string
+produces:
+- application/json
+swagger: '2.0'
+tags:
+- description: description
+  name: foo

--- a/tests/cases/py_client/common_parameters/client.py
+++ b/tests/cases/py_client/common_parameters/client.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!
+"""Implements the client for foo."""
+
+# pylint: skip-file
+# pydocstyle: add-ignore=D105,D107,D401
+
+import contextlib
+import json
+from typing import Any, BinaryIO, Dict, List, MutableMapping, Optional, cast
+
+import requests
+import requests.auth
+
+
+class RemoteCaller:
+    """Executes the remote calls to the server."""
+
+    def __init__(
+        self,
+        url_prefix: str,
+        auth: Optional[requests.auth.AuthBase] = None,
+        session: Optional[requests.Session] = None) -> None:
+        self.url_prefix = url_prefix
+        self.auth = auth
+        self.session = session
+
+        if not self.session:
+            self.session = requests.Session()
+            self.session.auth = self.auth
+
+    def get_foo(
+            self,
+            foo_id: str) -> bytes:
+        """
+        Send a get request to /api/v1/foo/{foo_id}.
+
+        :param foo_id: The foo id
+
+        :return: Success
+        """
+        url = "".join([
+            self.url_prefix,
+            '/api/v1/foo/',
+            str(foo_id)])
+
+        resp = self.session.request(
+            method='get',
+            url=url,
+        )
+
+        with contextlib.closing(resp):
+            resp.raise_for_status()
+            return resp.content
+
+
+# Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/py_client/common_parameters/swagger.yaml
+++ b/tests/cases/py_client/common_parameters/swagger.yaml
@@ -1,0 +1,30 @@
+# This is a valid schema, but it broke swagger-to.
+# Please see the issue: https://github.com/Parquery/swagger-to/issues/68
+basePath: /api/v1
+consumes:
+- application/json
+info:
+  description: An API
+  title: An API
+  version: '1.0'
+paths:
+  /foo/{foo_id}:
+    get:
+      operationId: get_foo
+      responses:
+        '200':
+          description: Success
+      tags:
+      - foo
+    parameters:
+    - in: path
+      description: The foo id
+      name: foo_id
+      required: true
+      type: string
+produces:
+- application/json
+swagger: '2.0'
+tags:
+- description: description
+  name: foo

--- a/tests/test_elm_client.py
+++ b/tests/test_elm_client.py
@@ -46,7 +46,6 @@ class TestElmClient(unittest.TestCase):
             swagger_to.elm_client.write_client_elm(typedefs=elm_typedefs, requests=elm_requests, fid=buffid)
 
             got = buf.getvalue()
-
             expected = (case_dir / "Client.elm").read_text()
             self.assertEqual(expected, got)
 

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Test that parsing does not break on certain edge cases."""
+import os
+import pathlib
+import unittest
+
+import swagger_to.go_server
+import swagger_to.intermediate
+import swagger_to.swagger
+
+# pylint: disable=missing-docstring
+# pylint: disable=protected-access
+
+
+class TestParsing(unittest.TestCase):
+    def test_that_common_parameters_are_correctly_parsed(self):
+        tests_dir = pathlib.Path(os.path.realpath(__file__)).parent
+
+        cases_dir = tests_dir / "cases" / "parsing"
+
+        for case_dir in sorted(cases_dir.iterdir()):
+            swagger_path = case_dir / "swagger.yaml"
+
+            _, errs = swagger_to.swagger.parse_yaml_file(path=swagger_path)
+
+            expected_errs_pth = case_dir / "errors.txt"
+            expected_errs = expected_errs_pth.read_text()
+
+            self.assertEqual(expected_errs, "\n".join(errs),
+                             "Mismatch against the expected errors from {}".format(expected_errs_pth))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_swagger_to.py
+++ b/tests/test_swagger_to.py
@@ -9,7 +9,7 @@ import swagger_to.intermediate
 import swagger_to.swagger
 
 
-class TestSwaggerToGo(unittest.TestCase):
+class TestSwaggerTo(unittest.TestCase):
     def test_camel_case_split(self):
         table = [('CvSizeInt', ['Cv', 'Size', 'Int']), ('SomeURLs', ['Some', 'URLs'])]
 


### PR DESCRIPTION
This patch adds support for common parameters in a path. This was
previously omitted since Parquery's code base did not make use of it and
we were ignorant of the details (see
https://swagger.io/docs/specification/2-0/describing-parameters/,
Section "Common Parameters").

This fixes issue #68.