### PR TITLE
Fixed line number while parsing Swagger spec

### DIFF
--- a/tests/cases/intermediate/general/endpoints.json
+++ b/tests/cases/intermediate/general/endpoints.json
@@ -2,7 +2,7 @@
   {
     "consumes": [],
     "description": "The Products endpoint returns information about the Uber products offered at a given location.",
-    "line": 42,
+    "line": 14,
     "method": "get",
     "operation_id": "products",
     "parameters": [
@@ -13,7 +13,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 27,
+        "line": 20,
         "name": "latitude",
         "required": true,
         "typedef": {
@@ -36,7 +36,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 33,
+        "line": 26,
         "name": "longitude",
         "required": true,
         "typedef": {
@@ -61,7 +61,7 @@
       "200": {
         "code": "200",
         "description": "An array of products",
-        "line": 40,
+        "line": 36,
         "typedef": {
           "description": "",
           "identifier": "ProductMap",
@@ -69,7 +69,7 @@
             "identifier": "ProductMap",
             "text": "{\n  \"title\": \"ProductMap\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Product\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"product_id\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n        },\n        \"desc\": {\n          \"type\": \"string\",\n          \"description\": \"Description of product.\"\n        },\n        \"display_name\": {\n          \"type\": \"string\",\n          \"description\": \"Display name of product.\"\n        },\n        \"capacity\": {\n          \"type\": \"integer\",\n          \"format\": \"int32\",\n          \"description\": \"Capacity of product. For example, 4 people.\"\n        },\n        \"image\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL representing the product.\"\n        }\n      },\n      \"required\": [\n        \"product_id\",\n        \"desc\",\n        \"display_name\",\n        \"capacity\",\n        \"image\"\n      ]\n    }\n  },\n  \"type\": \"object\",\n  \"additionalProperties\": {\n    \"$ref\": \"#/definitions/Product\"\n  }\n}"
           },
-          "line": 251,
+          "line": 247,
           "values": {
             "description": "",
             "identifier": "Product",
@@ -77,7 +77,7 @@
               "identifier": "Product",
               "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
             },
-            "line": 237,
+            "line": 210,
             "properties": {
               "product_id": {
                 "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -92,7 +92,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 218,
+                  "line": 213,
                   "pattern": "",
                   "type": "string"
                 }
@@ -110,7 +110,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 221,
+                  "line": 218,
                   "pattern": "",
                   "type": "string"
                 }
@@ -128,7 +128,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 224,
+                  "line": 221,
                   "pattern": "",
                   "type": "string"
                 }
@@ -146,7 +146,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 228,
+                  "line": 224,
                   "pattern": "",
                   "type": "integer"
                 }
@@ -164,7 +164,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 231,
+                  "line": 228,
                   "pattern": "",
                   "type": "string"
                 }
@@ -183,7 +183,7 @@
       "default": {
         "code": "default",
         "description": "Unexpected error",
-        "line": 42,
+        "line": 40,
         "typedef": null
       }
     }
@@ -191,7 +191,7 @@
   {
     "consumes": [],
     "description": "The Price Estimates endpoint returns an estimated price range for each product offered at a given\nlocation. The price estimate is provided as a formatted string with the full price range and the localized\ncurrency symbol.",
-    "line": 91,
+    "line": 43,
     "method": "get",
     "operation_id": "estimates_price",
     "parameters": [
@@ -202,7 +202,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 58,
+        "line": 51,
         "name": "start_latitude",
         "required": true,
         "typedef": {
@@ -225,7 +225,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 64,
+        "line": 57,
         "name": "start_longitude",
         "required": true,
         "typedef": {
@@ -248,7 +248,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 70,
+        "line": 63,
         "name": "end_latitude",
         "required": true,
         "typedef": {
@@ -271,7 +271,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 76,
+        "line": 69,
         "name": "end_longitude",
         "required": true,
         "typedef": {
@@ -294,7 +294,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 82,
+        "line": 75,
         "name": "max_lines",
         "required": false,
         "typedef": {
@@ -319,7 +319,7 @@
       "200": {
         "code": "200",
         "description": "An array of price estimates by product",
-        "line": 89,
+        "line": 85,
         "typedef": {
           "description": "",
           "identifier": "PriceEstimateArray",
@@ -330,7 +330,7 @@
               "identifier": "Product",
               "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
             },
-            "line": 237,
+            "line": 210,
             "properties": {
               "product_id": {
                 "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -345,7 +345,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 218,
+                  "line": 213,
                   "pattern": "",
                   "type": "string"
                 }
@@ -363,7 +363,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 221,
+                  "line": 218,
                   "pattern": "",
                   "type": "string"
                 }
@@ -381,7 +381,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 224,
+                  "line": 221,
                   "pattern": "",
                   "type": "string"
                 }
@@ -399,7 +399,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 228,
+                  "line": 224,
                   "pattern": "",
                   "type": "integer"
                 }
@@ -417,7 +417,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 231,
+                  "line": 228,
                   "pattern": "",
                   "type": "string"
                 }
@@ -435,13 +435,13 @@
             "identifier": "PriceEstimateArray",
             "text": "{\n  \"title\": \"PriceEstimateArray\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Product\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"product_id\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n        },\n        \"desc\": {\n          \"type\": \"string\",\n          \"description\": \"Description of product.\"\n        },\n        \"display_name\": {\n          \"type\": \"string\",\n          \"description\": \"Display name of product.\"\n        },\n        \"capacity\": {\n          \"type\": \"integer\",\n          \"format\": \"int32\",\n          \"description\": \"Capacity of product. For example, 4 people.\"\n        },\n        \"image\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL representing the product.\"\n        }\n      },\n      \"required\": [\n        \"product_id\",\n        \"desc\",\n        \"display_name\",\n        \"capacity\",\n        \"image\"\n      ]\n    }\n  },\n  \"type\": \"array\",\n  \"items\": {\n    \"$ref\": \"#/definitions/Product\"\n  }\n}"
           },
-          "line": 293
+          "line": 289
         }
       },
       "default": {
         "code": "default",
         "description": "Unexpected error",
-        "line": 91,
+        "line": 89,
         "typedef": null
       }
     }
@@ -449,7 +449,7 @@
   {
     "consumes": [],
     "description": "The Time Estimates endpoint returns ETAs for all products.",
-    "line": 128,
+    "line": 92,
     "method": "get",
     "operation_id": "estimates_time",
     "parameters": [
@@ -460,7 +460,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 104,
+        "line": 97,
         "name": "start_latitude",
         "required": true,
         "typedef": {
@@ -483,7 +483,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 110,
+        "line": 103,
         "name": "start_longitude",
         "required": true,
         "typedef": {
@@ -506,7 +506,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 115,
+        "line": 109,
         "name": "customer_uuid",
         "required": false,
         "typedef": {
@@ -529,7 +529,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 119,
+        "line": 114,
         "name": "product_id",
         "required": false,
         "typedef": {
@@ -554,7 +554,7 @@
       "200": {
         "code": "200",
         "description": "An array of products",
-        "line": 126,
+        "line": 122,
         "typedef": {
           "description": "",
           "identifier": "ProductMap",
@@ -562,7 +562,7 @@
             "identifier": "ProductMap",
             "text": "{\n  \"title\": \"ProductMap\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Product\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"product_id\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n        },\n        \"desc\": {\n          \"type\": \"string\",\n          \"description\": \"Description of product.\"\n        },\n        \"display_name\": {\n          \"type\": \"string\",\n          \"description\": \"Display name of product.\"\n        },\n        \"capacity\": {\n          \"type\": \"integer\",\n          \"format\": \"int32\",\n          \"description\": \"Capacity of product. For example, 4 people.\"\n        },\n        \"image\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL representing the product.\"\n        }\n      },\n      \"required\": [\n        \"product_id\",\n        \"desc\",\n        \"display_name\",\n        \"capacity\",\n        \"image\"\n      ]\n    }\n  },\n  \"type\": \"object\",\n  \"additionalProperties\": {\n    \"$ref\": \"#/definitions/Product\"\n  }\n}"
           },
-          "line": 251,
+          "line": 247,
           "values": {
             "description": "",
             "identifier": "Product",
@@ -570,7 +570,7 @@
               "identifier": "Product",
               "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
             },
-            "line": 237,
+            "line": 210,
             "properties": {
               "product_id": {
                 "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -585,7 +585,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 218,
+                  "line": 213,
                   "pattern": "",
                   "type": "string"
                 }
@@ -603,7 +603,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 221,
+                  "line": 218,
                   "pattern": "",
                   "type": "string"
                 }
@@ -621,7 +621,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 224,
+                  "line": 221,
                   "pattern": "",
                   "type": "string"
                 }
@@ -639,7 +639,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 228,
+                  "line": 224,
                   "pattern": "",
                   "type": "integer"
                 }
@@ -657,7 +657,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 231,
+                  "line": 228,
                   "pattern": "",
                   "type": "string"
                 }
@@ -676,7 +676,7 @@
       "default": {
         "code": "default",
         "description": "Unexpected error",
-        "line": 128,
+        "line": 126,
         "typedef": null
       }
     }
@@ -686,7 +686,7 @@
       "application/json"
     ],
     "description": "Update an User Profile.",
-    "line": 152,
+    "line": 129,
     "method": "patch",
     "operation_id": "update_me",
     "parameters": [
@@ -697,7 +697,7 @@
           "identifier": "Profile",
           "text": "{\n  \"title\": \"Profile\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Profile\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"first_name\": {\n          \"type\": \"string\",\n          \"description\": \"First name of the Uber user.\"\n        },\n        \"last_name\": {\n          \"type\": \"string\",\n          \"description\": \"Last name of the Uber user.\"\n        },\n        \"email\": {\n          \"type\": \"string\",\n          \"description\": \"Email address of the Uber user\"\n        },\n        \"picture\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL of the Uber user.\"\n        },\n        \"promo_code\": {\n          \"type\": \"string\",\n          \"description\": \"Promo code of the Uber user.\"\n        }\n      },\n      \"required\": [\n        \"last_name\",\n        \"email\",\n        \"picture\"\n      ]\n    }\n  },\n  \"$ref\": \"#/definitions/Profile\"\n}"
         },
-        "line": 145,
+        "line": 138,
         "name": "update_user",
         "required": true,
         "typedef": "reference to a typedef with identifier Profile"
@@ -711,7 +711,7 @@
       "200": {
         "code": "200",
         "description": "Previous profile information for a user",
-        "line": 150,
+        "line": 146,
         "typedef": {
           "description": "",
           "identifier": "Profile",
@@ -719,7 +719,7 @@
             "identifier": "Profile",
             "text": "{\n  \"title\": \"Profile\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"first_name\": {\n      \"type\": \"string\",\n      \"description\": \"First name of the Uber user.\"\n    },\n    \"last_name\": {\n      \"type\": \"string\",\n      \"description\": \"Last name of the Uber user.\"\n    },\n    \"email\": {\n      \"type\": \"string\",\n      \"description\": \"Email address of the Uber user\"\n    },\n    \"picture\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL of the Uber user.\"\n    },\n    \"promo_code\": {\n      \"type\": \"string\",\n      \"description\": \"Promo code of the Uber user.\"\n    }\n  },\n  \"required\": [\n    \"last_name\",\n    \"email\",\n    \"picture\"\n  ]\n}"
           },
-          "line": 315,
+          "line": 293,
           "properties": {
             "first_name": {
               "description": "First name of the Uber user.",
@@ -734,7 +734,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 299,
+                "line": 296,
                 "pattern": "",
                 "type": "string"
               }
@@ -752,7 +752,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 302,
+                "line": 299,
                 "pattern": "",
                 "type": "string"
               }
@@ -770,7 +770,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 305,
+                "line": 302,
                 "pattern": "",
                 "type": "string"
               }
@@ -788,7 +788,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 308,
+                "line": 305,
                 "pattern": "",
                 "type": "string"
               }
@@ -806,7 +806,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 311,
+                "line": 308,
                 "pattern": "",
                 "type": "string"
               }
@@ -822,7 +822,7 @@
       "default": {
         "code": "default",
         "description": "Unexpected error",
-        "line": 152,
+        "line": 150,
         "typedef": null
       }
     }
@@ -832,7 +832,7 @@
       "multipart/form-data"
     ],
     "description": "Upload information about an User.",
-    "line": 181,
+    "line": 153,
     "method": "patch",
     "operation_id": "upload_infos",
     "parameters": [
@@ -843,7 +843,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 166,
+        "line": 160,
         "name": "user_id",
         "required": true,
         "typedef": {
@@ -866,7 +866,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 171,
+        "line": 165,
         "name": "profile_picture",
         "required": true,
         "typedef": {
@@ -889,7 +889,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 176,
+        "line": 170,
         "name": "birthday",
         "required": false,
         "typedef": {
@@ -912,13 +912,13 @@
       "200": {
         "code": "200",
         "description": "Confirms that the information was uploaded.",
-        "line": 179,
+        "line": 177,
         "typedef": null
       },
       "default": {
         "code": "default",
         "description": "Unexpected error",
-        "line": 181,
+        "line": 179,
         "typedef": null
       }
     }
@@ -926,7 +926,7 @@
   {
     "consumes": [],
     "description": "The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will\ninclude pickup locations and times, dropoff locations and times, the distance of past requests, and\ninformation about which products were requested.",
-    "line": 209,
+    "line": 182,
     "method": "get",
     "operation_id": "history",
     "parameters": [
@@ -937,7 +937,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 196,
+        "line": 190,
         "name": "offset",
         "required": false,
         "typedef": {
@@ -960,7 +960,7 @@
           "identifier": "",
           "text": ""
         },
-        "line": 201,
+        "line": 195,
         "name": "limit",
         "required": false,
         "typedef": {
@@ -983,7 +983,7 @@
       "200": {
         "code": "200",
         "description": "History information for the given user",
-        "line": 206,
+        "line": 202,
         "typedef": {
           "description": "",
           "identifier": "Activities",
@@ -991,7 +991,7 @@
             "identifier": "Activities",
             "text": "{\n  \"title\": \"Activities\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Activity\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"uuid\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier for the activity\"\n        }\n      },\n      \"required\": [\n        \"uuid\"\n      ]\n    }\n  },\n  \"type\": \"object\",\n  \"properties\": {\n    \"offset\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Position in pagination.\"\n    },\n    \"limit\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Number of items to retrieve (100 max).\"\n    },\n    \"count\": {\n      \"type\": \"integer\",\n      \"format\": \"int64\",\n      \"description\": \"Total number of items available.\"\n    },\n    \"history\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"$ref\": \"#/definitions/Activity\"\n      }\n    }\n  },\n  \"required\": [\n    \"offset\",\n    \"limit\",\n    \"count\",\n    \"history\"\n  ]\n}"
           },
-          "line": 346,
+          "line": 323,
           "properties": {
             "offset": {
               "description": "Position in pagination.",
@@ -1006,7 +1006,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 330,
+                "line": 326,
                 "pattern": "",
                 "type": "integer"
               }
@@ -1024,7 +1024,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 334,
+                "line": 330,
                 "pattern": "",
                 "type": "integer"
               }
@@ -1042,7 +1042,7 @@
                   "identifier": "",
                   "text": ""
                 },
-                "line": 338,
+                "line": 334,
                 "pattern": "",
                 "type": "integer"
               }
@@ -1062,7 +1062,7 @@
                     "identifier": "Activity",
                     "text": "{\n  \"title\": \"Activity\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"uuid\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier for the activity\"\n    }\n  },\n  \"required\": [\n    \"uuid\"\n  ]\n}"
                   },
-                  "line": 323,
+                  "line": 315,
                   "properties": {
                     "uuid": {
                       "description": "Unique identifier for the activity",
@@ -1077,7 +1077,7 @@
                           "identifier": "",
                           "text": ""
                         },
-                        "line": 321,
+                        "line": 318,
                         "pattern": "",
                         "type": "string"
                       }
@@ -1106,7 +1106,7 @@
       "default": {
         "code": "default",
         "description": "Unexpected error",
-        "line": 209,
+        "line": 206,
         "typedef": null
       }
     }

--- a/tests/cases/intermediate/general/intermediate_typedefs.json
+++ b/tests/cases/intermediate/general/intermediate_typedefs.json
@@ -6,7 +6,7 @@
       "identifier": "Product",
       "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
     },
-    "line": 237,
+    "line": 210,
     "properties": {
       "product_id": {
         "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -21,7 +21,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 218,
+          "line": 213,
           "pattern": "",
           "type": "string"
         }
@@ -39,7 +39,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 221,
+          "line": 218,
           "pattern": "",
           "type": "string"
         }
@@ -57,7 +57,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 224,
+          "line": 221,
           "pattern": "",
           "type": "string"
         }
@@ -75,7 +75,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 228,
+          "line": 224,
           "pattern": "",
           "type": "integer"
         }
@@ -93,7 +93,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 231,
+          "line": 228,
           "pattern": "",
           "type": "string"
         }
@@ -114,7 +114,7 @@
       "identifier": "ProductList",
       "text": "{\n  \"title\": \"ProductList\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Product\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"product_id\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n        },\n        \"desc\": {\n          \"type\": \"string\",\n          \"description\": \"Description of product.\"\n        },\n        \"display_name\": {\n          \"type\": \"string\",\n          \"description\": \"Display name of product.\"\n        },\n        \"capacity\": {\n          \"type\": \"integer\",\n          \"format\": \"int32\",\n          \"description\": \"Capacity of product. For example, 4 people.\"\n        },\n        \"image\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL representing the product.\"\n        }\n      },\n      \"required\": [\n        \"product_id\",\n        \"desc\",\n        \"display_name\",\n        \"capacity\",\n        \"image\"\n      ]\n    }\n  },\n  \"type\": \"object\",\n  \"properties\": {\n    \"products\": {\n      \"description\": \"Contains the list of products\",\n      \"type\": \"array\",\n      \"items\": {\n        \"$ref\": \"#/definitions/Product\"\n      }\n    }\n  },\n  \"required\": [\n    \"products\"\n  ]\n}"
     },
-    "line": 247,
+    "line": 237,
     "properties": {
       "products": {
         "description": "Contains the list of products",
@@ -131,7 +131,7 @@
               "identifier": "Product",
               "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
             },
-            "line": 237,
+            "line": 210,
             "properties": {
               "product_id": {
                 "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -146,7 +146,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 218,
+                  "line": 213,
                   "pattern": "",
                   "type": "string"
                 }
@@ -164,7 +164,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 221,
+                  "line": 218,
                   "pattern": "",
                   "type": "string"
                 }
@@ -182,7 +182,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 224,
+                  "line": 221,
                   "pattern": "",
                   "type": "string"
                 }
@@ -200,7 +200,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 228,
+                  "line": 224,
                   "pattern": "",
                   "type": "integer"
                 }
@@ -218,7 +218,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 231,
+                  "line": 228,
                   "pattern": "",
                   "type": "string"
                 }
@@ -251,7 +251,7 @@
       "identifier": "ProductMap",
       "text": "{\n  \"title\": \"ProductMap\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Product\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"product_id\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n        },\n        \"desc\": {\n          \"type\": \"string\",\n          \"description\": \"Description of product.\"\n        },\n        \"display_name\": {\n          \"type\": \"string\",\n          \"description\": \"Display name of product.\"\n        },\n        \"capacity\": {\n          \"type\": \"integer\",\n          \"format\": \"int32\",\n          \"description\": \"Capacity of product. For example, 4 people.\"\n        },\n        \"image\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL representing the product.\"\n        }\n      },\n      \"required\": [\n        \"product_id\",\n        \"desc\",\n        \"display_name\",\n        \"capacity\",\n        \"image\"\n      ]\n    }\n  },\n  \"type\": \"object\",\n  \"additionalProperties\": {\n    \"$ref\": \"#/definitions/Product\"\n  }\n}"
     },
-    "line": 251,
+    "line": 247,
     "values": {
       "description": "",
       "identifier": "Product",
@@ -259,7 +259,7 @@
         "identifier": "Product",
         "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
       },
-      "line": 237,
+      "line": 210,
       "properties": {
         "product_id": {
           "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -274,7 +274,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 218,
+            "line": 213,
             "pattern": "",
             "type": "string"
           }
@@ -292,7 +292,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 221,
+            "line": 218,
             "pattern": "",
             "type": "string"
           }
@@ -310,7 +310,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 224,
+            "line": 221,
             "pattern": "",
             "type": "string"
           }
@@ -328,7 +328,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 228,
+            "line": 224,
             "pattern": "",
             "type": "integer"
           }
@@ -346,7 +346,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 231,
+            "line": 228,
             "pattern": "",
             "type": "string"
           }
@@ -368,7 +368,7 @@
       "identifier": "PriceEstimate",
       "text": "{\n  \"title\": \"PriceEstimate\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude. For example,\\nuberX in San Francisco will have a different product_id than uberX in Los Angeles\"\n    },\n    \"currency_code\": {\n      \"type\": \"string\",\n      \"description\": \"[ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) currency code.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"estimate\": {\n      \"type\": \"string\",\n      \"description\": \"Formatted string of estimate in local currency of the start location.\\nEstimate could be a range, a single number (flat rate) or \\\"Metered\\\" for TAXI.\"\n    },\n    \"low_estimate\": {\n      \"type\": \"number\",\n      \"format\": \"double\",\n      \"description\": \"Lower bound of the estimated price.\"\n    },\n    \"high_estimate\": {\n      \"type\": \"number\",\n      \"format\": \"double\",\n      \"description\": \"Upper bound of the estimated price.\"\n    },\n    \"surge_multiplier\": {\n      \"type\": \"number\",\n      \"format\": \"double\",\n      \"description\": \"Expected surge multiplier. Surge is active if surge_multiplier is greater than 1.\\nPrice estimate already factors in the surge multiplier.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"currency_code\",\n    \"display_name\",\n    \"estimate\"\n  ]\n}"
     },
-    "line": 289,
+    "line": 251,
     "properties": {
       "product_id": {
         "description": "Unique identifier representing a specific product for a given latitude & longitude. For example,\nuberX in San Francisco will have a different product_id than uberX in Los Angeles",
@@ -383,7 +383,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 259,
+          "line": 254,
           "pattern": "",
           "type": "string"
         }
@@ -401,7 +401,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 262,
+          "line": 259,
           "pattern": "",
           "type": "string"
         }
@@ -419,7 +419,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 265,
+          "line": 262,
           "pattern": "",
           "type": "string"
         }
@@ -437,7 +437,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 270,
+          "line": 265,
           "pattern": "",
           "type": "string"
         }
@@ -455,7 +455,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 274,
+          "line": 270,
           "pattern": "",
           "type": "number"
         }
@@ -473,7 +473,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 278,
+          "line": 274,
           "pattern": "",
           "type": "number"
         }
@@ -491,7 +491,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 284,
+          "line": 278,
           "pattern": "",
           "type": "number"
         }
@@ -514,7 +514,7 @@
         "identifier": "Product",
         "text": "{\n  \"title\": \"Product\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"product_id\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n    },\n    \"desc\": {\n      \"type\": \"string\",\n      \"description\": \"Description of product.\"\n    },\n    \"display_name\": {\n      \"type\": \"string\",\n      \"description\": \"Display name of product.\"\n    },\n    \"capacity\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Capacity of product. For example, 4 people.\"\n    },\n    \"image\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL representing the product.\"\n    }\n  },\n  \"required\": [\n    \"product_id\",\n    \"desc\",\n    \"display_name\",\n    \"capacity\",\n    \"image\"\n  ]\n}"
       },
-      "line": 237,
+      "line": 210,
       "properties": {
         "product_id": {
           "description": "Unique identifier representing a specific product for a given latitude & longitude.\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.",
@@ -529,7 +529,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 218,
+            "line": 213,
             "pattern": "",
             "type": "string"
           }
@@ -547,7 +547,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 221,
+            "line": 218,
             "pattern": "",
             "type": "string"
           }
@@ -565,7 +565,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 224,
+            "line": 221,
             "pattern": "",
             "type": "string"
           }
@@ -583,7 +583,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 228,
+            "line": 224,
             "pattern": "",
             "type": "integer"
           }
@@ -601,7 +601,7 @@
               "identifier": "",
               "text": ""
             },
-            "line": 231,
+            "line": 228,
             "pattern": "",
             "type": "string"
           }
@@ -619,7 +619,7 @@
       "identifier": "PriceEstimateArray",
       "text": "{\n  \"title\": \"PriceEstimateArray\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Product\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"product_id\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier representing a specific product for a given latitude & longitude.\\nFor example, uberX in San Francisco will have a different product_id than uberX in Los Angeles.\"\n        },\n        \"desc\": {\n          \"type\": \"string\",\n          \"description\": \"Description of product.\"\n        },\n        \"display_name\": {\n          \"type\": \"string\",\n          \"description\": \"Display name of product.\"\n        },\n        \"capacity\": {\n          \"type\": \"integer\",\n          \"format\": \"int32\",\n          \"description\": \"Capacity of product. For example, 4 people.\"\n        },\n        \"image\": {\n          \"type\": \"string\",\n          \"description\": \"Image URL representing the product.\"\n        }\n      },\n      \"required\": [\n        \"product_id\",\n        \"desc\",\n        \"display_name\",\n        \"capacity\",\n        \"image\"\n      ]\n    }\n  },\n  \"type\": \"array\",\n  \"items\": {\n    \"$ref\": \"#/definitions/Product\"\n  }\n}"
     },
-    "line": 293
+    "line": 289
   },
   "Profile": {
     "description": "",
@@ -628,7 +628,7 @@
       "identifier": "Profile",
       "text": "{\n  \"title\": \"Profile\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"first_name\": {\n      \"type\": \"string\",\n      \"description\": \"First name of the Uber user.\"\n    },\n    \"last_name\": {\n      \"type\": \"string\",\n      \"description\": \"Last name of the Uber user.\"\n    },\n    \"email\": {\n      \"type\": \"string\",\n      \"description\": \"Email address of the Uber user\"\n    },\n    \"picture\": {\n      \"type\": \"string\",\n      \"description\": \"Image URL of the Uber user.\"\n    },\n    \"promo_code\": {\n      \"type\": \"string\",\n      \"description\": \"Promo code of the Uber user.\"\n    }\n  },\n  \"required\": [\n    \"last_name\",\n    \"email\",\n    \"picture\"\n  ]\n}"
     },
-    "line": 315,
+    "line": 293,
     "properties": {
       "first_name": {
         "description": "First name of the Uber user.",
@@ -643,7 +643,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 299,
+          "line": 296,
           "pattern": "",
           "type": "string"
         }
@@ -661,7 +661,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 302,
+          "line": 299,
           "pattern": "",
           "type": "string"
         }
@@ -679,7 +679,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 305,
+          "line": 302,
           "pattern": "",
           "type": "string"
         }
@@ -697,7 +697,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 308,
+          "line": 305,
           "pattern": "",
           "type": "string"
         }
@@ -715,7 +715,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 311,
+          "line": 308,
           "pattern": "",
           "type": "string"
         }
@@ -734,7 +734,7 @@
       "identifier": "Activity",
       "text": "{\n  \"title\": \"Activity\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"uuid\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier for the activity\"\n    }\n  },\n  \"required\": [\n    \"uuid\"\n  ]\n}"
     },
-    "line": 323,
+    "line": 315,
     "properties": {
       "uuid": {
         "description": "Unique identifier for the activity",
@@ -749,7 +749,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 321,
+          "line": 318,
           "pattern": "",
           "type": "string"
         }
@@ -766,7 +766,7 @@
       "identifier": "Activities",
       "text": "{\n  \"title\": \"Activities\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"definitions\": {\n    \"Activity\": {\n      \"type\": \"object\",\n      \"properties\": {\n        \"uuid\": {\n          \"type\": \"string\",\n          \"description\": \"Unique identifier for the activity\"\n        }\n      },\n      \"required\": [\n        \"uuid\"\n      ]\n    }\n  },\n  \"type\": \"object\",\n  \"properties\": {\n    \"offset\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Position in pagination.\"\n    },\n    \"limit\": {\n      \"type\": \"integer\",\n      \"format\": \"int32\",\n      \"description\": \"Number of items to retrieve (100 max).\"\n    },\n    \"count\": {\n      \"type\": \"integer\",\n      \"format\": \"int64\",\n      \"description\": \"Total number of items available.\"\n    },\n    \"history\": {\n      \"type\": \"array\",\n      \"items\": {\n        \"$ref\": \"#/definitions/Activity\"\n      }\n    }\n  },\n  \"required\": [\n    \"offset\",\n    \"limit\",\n    \"count\",\n    \"history\"\n  ]\n}"
     },
-    "line": 346,
+    "line": 323,
     "properties": {
       "offset": {
         "description": "Position in pagination.",
@@ -781,7 +781,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 330,
+          "line": 326,
           "pattern": "",
           "type": "integer"
         }
@@ -799,7 +799,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 334,
+          "line": 330,
           "pattern": "",
           "type": "integer"
         }
@@ -817,7 +817,7 @@
             "identifier": "",
             "text": ""
           },
-          "line": 338,
+          "line": 334,
           "pattern": "",
           "type": "integer"
         }
@@ -837,7 +837,7 @@
               "identifier": "Activity",
               "text": "{\n  \"title\": \"Activity\",\n  \"$schema\": \"http://json-schema.org/draft-04/schema#\",\n  \"type\": \"object\",\n  \"properties\": {\n    \"uuid\": {\n      \"type\": \"string\",\n      \"description\": \"Unique identifier for the activity\"\n    }\n  },\n  \"required\": [\n    \"uuid\"\n  ]\n}"
             },
-            "line": 323,
+            "line": 315,
             "properties": {
               "uuid": {
                 "description": "Unique identifier for the activity",
@@ -852,7 +852,7 @@
                     "identifier": "",
                     "text": ""
                   },
-                  "line": 321,
+                  "line": 318,
                   "pattern": "",
                   "type": "string"
                 }

--- a/tests/test_intermediate.py
+++ b/tests/test_intermediate.py
@@ -56,6 +56,8 @@ def jsonize(what: Any) -> Any:
 
 class TestIntermediate(unittest.TestCase):
     def test_that_it_does_not_break(self):
+        self.maxDiff = None
+
         tests_dir = pathlib.Path(os.path.realpath(__file__)).parent
 
         cases_dir = tests_dir / "cases" / "intermediate"
@@ -74,18 +76,25 @@ class TestIntermediate(unittest.TestCase):
                 swagger=swagger, typedefs=inter_typedefs, params=inter_params)
 
             inter_typedefs_pth = case_dir / "intermediate_typedefs.json"
+            inter_params_pth = case_dir / "intermediate_params.json"
+            endpoints_pth = case_dir / "endpoints.json"
+
+            # Leave this snippet here to facilitate updating the tests in the future
+            # inter_typedefs_pth.write_text(json.dumps(jsonize(inter_typedefs), indent=2))
+            # inter_params_pth.write_text(json.dumps(jsonize(inter_params), indent=2))
+            # endpoints_pth.write_text(json.dumps(jsonize(endpoints), indent=2))
+
             self.assertEqual(
                 inter_typedefs_pth.read_text(), json.dumps(jsonize(inter_typedefs), indent=2),
                 "Expected content from {} does not match the jsonized typedefs.".format(inter_typedefs_pth))
 
-            inter_params_pth = case_dir / "intermediate_params.json"
-            self.assertEqual(inter_params_pth.read_text(), json.dumps(jsonize(inter_params), indent=2),
+            self.assertEqual(
+                inter_params_pth.read_text(), json.dumps(jsonize(inter_params), indent=2),
                              "Expected content from {} does not match the jsonized params.".format(inter_params_pth))
 
-            inter_endpoints_pth = case_dir / "endpoints.json"
             self.assertEqual(
-                inter_endpoints_pth.read_text(), json.dumps(jsonize(endpoints), indent=2),
-                "Expected content from {} does not match the jsonized endpoints.".format(inter_endpoints_pth))
+                endpoints_pth.read_text(), json.dumps(jsonize(endpoints), indent=2),
+                "Expected content from {} does not match the jsonized endpoints.".format(endpoints_pth))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch fixes how the line number of an YAML object is determined
when parsing the Swagger spec. Previously, there was a bug that made the
line number correspond to the *end* of the object instead of its start.