### PR TITLE
Escaped OperationIds for valid Elm identifiers

### DIFF
--- a/swagger_to/elm_client.py
+++ b/swagger_to/elm_client.py
@@ -1097,7 +1097,7 @@ def _request_function_name(operation_id: str) -> str:
 
     >>> _request_function_name('__')
     '__'
- 
+
     >>> _request_function_name('test.me')
     'testMe'
 

--- a/tests/cases/elm_client/dotted_operation_ids/Client.elm
+++ b/tests/cases/elm_client/dotted_operation_ids/Client.elm
@@ -1,0 +1,42 @@
+-- Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!
+
+
+module Client 
+    exposing
+        ( getFooRequest
+        )
+
+import Dict exposing (Dict)
+import Http
+import Json.Decode
+import Json.Decode.Pipeline
+import Json.Encode
+import Json.Encode.Extra
+import Time
+
+
+-- Remote Calls
+
+
+
+{-| Contains a "get" request to the endpoint: `/api/v1/foo/{foo_id}`, to be sent with Http.send
+-}
+getFooRequest : String -> Maybe Time.Time -> Bool -> String -> Http.Request String
+getFooRequest prefix maybeTimeout withCredentials fooID =
+    let
+        url = prefix
+            ++ "api/v1/foo/"
+            ++ fooID    in
+    Http.request
+        { body = Http.emptyBody
+        , expect = Http.expectString
+        , headers = []
+        , method = "GET"
+        , timeout = maybeTimeout
+        , url = url
+        , withCredentials = withCredentials
+        }
+
+
+
+-- Automatically generated file by swagger_to. DO NOT EDIT OR APPEND ANYTHING!

--- a/tests/cases/elm_client/dotted_operation_ids/elm-package.json
+++ b/tests/cases/elm_client/dotted_operation_ids/elm-package.json
@@ -1,0 +1,17 @@
+{
+  "version": "1.1.0",
+  "summary": "",
+  "repository": "https://github.com/invalid/repo.git",
+  "license": "",
+  "source-directories": [
+    "src"
+  ],
+  "exposed-modules": [],
+  "dependencies": {
+    "elm-lang/core": "2.0.0 <= v <= 2.0.0",
+    "elm-lang/http": "1.0.0 <= v <= 1.0.0",
+    "elm-community/json-extra": "2.7.0 <= v <= 2.7.0",
+    "NoRedInk/elm-decode-pipeline": "3.0.0 <= v <= 3.0.0"
+  },
+  "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/tests/cases/elm_client/dotted_operation_ids/swagger.yaml
+++ b/tests/cases/elm_client/dotted_operation_ids/swagger.yaml
@@ -1,0 +1,30 @@
+# This is a valid schema, but it broke swagger-to.
+# Please see the issue: https://github.com/Parquery/swagger-to/issues/68
+basePath: /api/v1
+consumes:
+- application/json
+info:
+  description: An API
+  title: An API
+  version: '1.0'
+paths:
+  /foo/{foo_id}:
+    get:
+      operationId: get.foo
+      responses:
+        '200':
+          description: Success
+      tags:
+      - foo
+    parameters:
+    - in: path
+      description: The foo id
+      name: foo_id
+      required: true
+      type: string
+produces:
+- application/json
+swagger: '2.0'
+tags:
+- description: description
+  name: foo


### PR DESCRIPTION
This essentially replaces '.' with '\_' in operation-ids when 
generating function names in the Elm client output. This isn't a
completely bullet-proof solution - it could in principle create
collisions with operation-ids containing '_' - but I think in practice
it's sufficient, at least for now.