### PR TITLE
Removed support for Python 3.5

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',


### PR DESCRIPTION
Python 3.5 reached end-of-life in 2020. At least one of the dependencies
(icontract) does not support it anymore, so we had to also strip the
support for this package as well.

Note that this concerns only the environment where swagger-to is
executed. The generated code can be still assumed to run under Python
3.5.