### PR TITLE
Bumped to 4.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+4.1.1
+=====
+* Supported ``Any`` type value (i.e. empty type) (#126)
+* Removed support for Python 3.5 (#127)
+
 4.1.0
 =====
 * Propagated ``produces`` and ``consumes`` (#123)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='swagger_to',
-    version='4.1.0',  # Don't forget to update changelog!
+    version='4.1.1',  # Don't forget to update changelog!
     description='Generate server and client code from Swagger (OpenAPI 2.0) specification',
     long_description=long_description,
     url='https://github.com/Parquery/swagger-to',


### PR DESCRIPTION
* Supported `Any` type value (i.e. empty type) (#126)
* Removed support for Python 3.5 (#127)