### PR TITLE
Added quotes to type annotations in py client

### DIFF
--- a/swagger_to/py_client.py
+++ b/swagger_to/py_client.py
@@ -288,17 +288,22 @@ def _to_response(intermediate_response: swagger_to.intermediate.Response,
     return resp
 
 
+# yapf: disable
 @icontract.ensure(
     lambda result:
-    sorted(result.parameters, key=id) == sorted((
+    sorted(result.parameters, key=id) ==
+    sorted((
         param
-        for param in ([result.body_parameter] if result.body_parameter else []) +
-                     result.query_parameters +
-                     result.header_parameters +
-                     result.path_parameters +
-                     result.formdata_parameters +
-                     result.file_parameters), key=id),
+        for param in (
+             [result.body_parameter] if result.body_parameter else []) +
+             result.query_parameters +
+             result.header_parameters +
+             result.path_parameters +
+             result.formdata_parameters +
+             result.file_parameters),
+        key=id),
     enabled=icontract.SLOW)
+# yapf: enable
 @icontract.ensure(lambda result: all(isinstance(param.typedef, Filedef) for param in result.file_parameters))
 def _to_request(endpoint: swagger_to.intermediate.Endpoint, typedefs: MutableMapping[str, Typedef]) -> Request:
     """
@@ -509,9 +514,11 @@ def _raise(message: str) -> None:
 
 
 _NON_IDENTIFIER_RE = re.compile(r'[^a-zA-Z0-9_]')
+IDENTIFIER_RE = re.compile('[a-zA-Z_][a-zA-Z0-9_]*')
 
 
 @icontract.require(lambda name: name != '')
+@icontract.ensure(lambda result: IDENTIFIER_RE.fullmatch(result))
 def _function_name(name: str) -> str:
     """
     Generate the name of the function which will send the request based on the operation ID.
@@ -541,6 +548,7 @@ def _function_name(name: str) -> str:
 
 
 @icontract.require(lambda name: name != '')
+@icontract.ensure(lambda result: IDENTIFIER_RE.fullmatch(result))
 def _class_name(name: str) -> str:
     """
     Generate the Python name of the class corresponding to the Swagger definition.
@@ -564,6 +572,7 @@ def _class_name(name: str) -> str:
 
 
 @icontract.require(lambda name: name != '')
+@icontract.ensure(lambda result: IDENTIFIER_RE.fullmatch(result))
 def _property_name(name: str) -> str:
     """
     Generate the Python name of the property corresponding to the Swagger definition.
@@ -587,6 +596,7 @@ def _property_name(name: str) -> str:
 
 
 @icontract.require(lambda name: name != '')
+@icontract.ensure(lambda result: IDENTIFIER_RE.fullmatch(result))
 def _arg_name(name: str) -> str:
     """
     Generate the Python name of the argument corresponding to a Swagger definition.
@@ -610,6 +620,7 @@ def _arg_name(name: str) -> str:
 
 
 @icontract.require(lambda name: name != '')
+@icontract.ensure(lambda result: IDENTIFIER_RE.fullmatch(result))
 def _var_name(name: str) -> str:
     """
     Generate the Python name of the variable corresponding to a Swagger definition.
@@ -714,7 +725,7 @@ def _type_expression(typedef: Typedef, path: Optional[str] = None) -> str:
             raise NotImplementedError(('Translating an anonymous class to a type expression '
                                        'is not supported: {}').format(path))
 
-        return _class_name(typedef.identifier)
+        return "'{}'".format(_class_name(typedef.identifier))
     else:
         raise NotImplementedError('Translating the typedef to a type expression is not supported: {!r}: {}'.format(
             type(typedef), path))

--- a/tests/cases/py_client/additional_properties/client.py
+++ b/tests/cases/py_client/additional_properties/client.py
@@ -295,7 +295,7 @@ class RemoteCaller:
 
     def get_baz(
             self,
-            body: AnyTypeValuesContainerInProperty) -> AnyTypeValuesContainerInProperty:
+            body: 'AnyTypeValuesContainerInProperty') -> 'AnyTypeValuesContainerInProperty':
         """
         Send a post request to /baz.
 

--- a/tests/cases/py_client/date_time_property/client.py
+++ b/tests/cases/py_client/date_time_property/client.py
@@ -222,7 +222,7 @@ class RemoteCaller:
 
     def test_me(
             self,
-            test_object: Optional[TestObject] = None) -> TestObject:
+            test_object: Optional['TestObject'] = None) -> 'TestObject':
         """
         Is a test endpoint.
 

--- a/tests/cases/py_client/empty_schema/client.py
+++ b/tests/cases/py_client/empty_schema/client.py
@@ -278,7 +278,7 @@ class RemoteCaller:
 
     def test_endpoint(
             self,
-            required_empty_parameter: EmptyParameter) -> WithEmptyProperties:
+            required_empty_parameter: 'EmptyParameter') -> 'WithEmptyProperties':
         """
         Test empty schema
 

--- a/tests/cases/py_client/general/client.py
+++ b/tests/cases/py_client/general/client.py
@@ -293,7 +293,7 @@ def product_to_jsonable(
 class ProductList:
     def __init__(
             self,
-            products: List[Product]) -> None:
+            products: List['Product']) -> None:
         """Initializes with the given values."""
         # Contains the list of products
         self.products = products
@@ -332,7 +332,7 @@ def product_list_from_obj(obj: Any, path: str = "") -> ProductList:
     products_from_obj = from_obj(
         obj['products'],
         expected=[list, Product],
-        path=path + '.products')  # type: List[Product]
+        path=path + '.products')  # type: List['Product']
 
     return ProductList(
         products=products_from_obj)
@@ -712,7 +712,7 @@ class Activities:
             offset: int,
             limit: int,
             count: int,
-            history: List[Activity]) -> None:
+            history: List['Activity']) -> None:
         """Initializes with the given values."""
         # Position in pagination.
         self.offset = offset
@@ -777,7 +777,7 @@ def activities_from_obj(obj: Any, path: str = "") -> Activities:
     history_from_obj = from_obj(
         obj['history'],
         expected=[list, Activity],
-        path=path + '.history')  # type: List[Activity]
+        path=path + '.history')  # type: List['Activity']
 
     return Activities(
         offset=offset_from_obj,
@@ -831,7 +831,7 @@ class RemoteCaller:
     def products(
             self,
             latitude: float,
-            longitude: float) -> Dict[str, Product]:
+            longitude: float) -> Dict[str, 'Product']:
         """
         The Products endpoint returns information about the Uber products offered at a given location.
 
@@ -866,7 +866,7 @@ class RemoteCaller:
             start_longitude: float,
             end_latitude: float,
             end_longitude: float,
-            max_lines: Optional[int] = None) -> List[Product]:
+            max_lines: Optional[int] = None) -> List['Product']:
         """
         The Price Estimates endpoint returns an estimated price range for each product offered at a given
         location. The price estimate is provided as a formatted string with the full price range and the localized
@@ -913,7 +913,7 @@ class RemoteCaller:
             start_latitude: float,
             start_longitude: float,
             customer_uuid: Optional[str] = None,
-            product_id: Optional[str] = None) -> Dict[str, Product]:
+            product_id: Optional[str] = None) -> Dict[str, 'Product']:
         """
         The Time Estimates endpoint returns ETAs for all products.
 
@@ -952,7 +952,7 @@ class RemoteCaller:
 
     def update_me(
             self,
-            update_user: Profile) -> Profile:
+            update_user: 'Profile') -> 'Profile':
         """
         Update an User Profile.
 
@@ -1020,7 +1020,7 @@ class RemoteCaller:
     def history(
             self,
             offset: Optional[int] = None,
-            limit: Optional[int] = None) -> Activities:
+            limit: Optional[int] = None) -> 'Activities':
         """
         The User Activity endpoint returns data about a user's lifetime activity with Uber. The response will
         include pickup locations and times, dropoff locations and times, the distance of past requests, and

--- a/tests/cases/py_client/object_with_no_properties/client.py
+++ b/tests/cases/py_client/object_with_no_properties/client.py
@@ -199,7 +199,7 @@ class RemoteCaller:
 
     def test_me(
             self,
-            empty_object: Optional[EmptyObject] = None) -> EmptyObject:
+            empty_object: Optional['EmptyObject'] = None) -> 'EmptyObject':
         """
         Is a test endpoint.
 

--- a/tests/cases/py_client/object_with_optional_properties/client.py
+++ b/tests/cases/py_client/object_with_optional_properties/client.py
@@ -242,7 +242,7 @@ class RemoteCaller:
 
     def test_me(
             self,
-            test_object: Optional[TestObject] = None) -> TestObject:
+            test_object: Optional['TestObject'] = None) -> 'TestObject':
         """
         Is a test endpoint.
 

--- a/tests/cases/py_client/spaces_in_properties/client.py
+++ b/tests/cases/py_client/spaces_in_properties/client.py
@@ -223,7 +223,7 @@ class RemoteCaller:
 
     def do_something(
             self,
-            some_parameter: SomeDefinition) -> MutableMapping[str, Any]:
+            some_parameter: 'SomeDefinition') -> MutableMapping[str, Any]:
         """
         Send a post request to /do-something.
 


### PR DESCRIPTION
This patch adds quotes to class names in Python client. This is
necessary since Python's type annotations do not support forward
declarations and similiar mechanisms.