### PR TITLE
Upgrade to jinja2 >=3

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -27,14 +27,13 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
     ],
     license="License :: OSI Approved :: MIT License",
     keywords='swagger code generation python elm go typescript server client angular',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires=['pyyaml>=3.12', 'jinja2>=2.10,<3', 'icontract>=2.0.1,<3', 'jsonschema>=3,<4'],
+    install_requires=['pyyaml>=3.12', 'jinja2>=3', 'icontract>=2.0.1,<3', 'jsonschema>=3,<4'],
     extras_require={
         'dev': [
             'mypy==0.782',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py37, py36, py35
+envlist = py38, py37
 
 [testenv]
 deps = -e .[dev]


### PR DESCRIPTION
We upgrade to latest jinja2 due to the breakage in one of its
dependencies. We have to drop support for Python 3.6 as jinja2
dropped it as well.

Fixes #135.