### PR TITLE
Bumped to 4.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+4.1.2
+=====
+* Added support for Python 3.9 and 3.10 (#136)
+* Upgraded to jinja2 >=3 (#137)
+* Fixed endless loops due to recursive definitions (#131)
+* Added quotes to type annotations in py client (#130)
+
 4.1.1
 =====
 * Supported ``Any`` type value (i.e. empty type) (#126)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='swagger_to',
-    version='4.1.1',  # Don't forget to update changelog!
+    version='4.1.2',  # Don't forget to update changelog!
     description='Generate server and client code from Swagger (OpenAPI 2.0) specification',
     long_description=long_description,
     url='https://github.com/Parquery/swagger-to',


### PR DESCRIPTION
* Added support for Python 3.9 and 3.10 (#136)
* Upgraded to jinja2 >=3 (#137)
* Fixed endless loops due to recursive definitions (#131)
* Added quotes to type annotations in py client (#130)