### PR TITLE
Bumped to 5.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,13 @@
-4.1.2
+5.0.0
 =====
 * Added support for Python 3.9 and 3.10 (#136)
 * Upgraded to jinja2 >=3 (#137)
 * Fixed endless loops due to recursive definitions (#131)
 * Added quotes to type annotations in py client (#130)
+
+Breaking change
+---------------
+* We had to drop the support for Python 3.6 since jinja2 >= 3 does not support it anymore.
 
 4.1.1
 =====

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='swagger_to',
-    version='4.1.2',  # Don't forget to update changelog!
+    version='5.0.0',  # Don't forget to update changelog!
     description='Generate server and client code from Swagger (OpenAPI 2.0) specification',
     long_description=long_description,
     url='https://github.com/Parquery/swagger-to',


### PR DESCRIPTION
* Added support for Python 3.9 and 3.10 (#136)
* Upgraded to jinja2 >=3 (#137)
* Fixed endless loops due to recursive definitions (#131)
* Added quotes to type annotations in py client (#130)

Breaking change
---------------
* We had to drop the support for Python 3.6 since jinja2 >= 3 does not support it anymore.